### PR TITLE
Feat: add fuzz/property-based tests for token arithmetic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -27,6 +27,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.102"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+
+[[package]]
 name = "arbitrary"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -85,6 +91,27 @@ name = "base64ct"
 version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
+
+[[package]]
+name = "bit-set"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
+
+[[package]]
+name = "bitflags"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
 
 [[package]]
 name = "block-buffer"
@@ -180,7 +207,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
 dependencies = [
  "generic-array",
- "rand_core",
+ "rand_core 0.6.4",
  "subtle",
  "zeroize",
 ]
@@ -388,7 +415,7 @@ checksum = "70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9"
 dependencies = [
  "curve25519-dalek",
  "ed25519",
- "rand_core",
+ "rand_core 0.6.4",
  "serde",
  "sha2",
  "subtle",
@@ -413,7 +440,7 @@ dependencies = [
  "ff",
  "generic-array",
  "group",
- "rand_core",
+ "rand_core 0.6.4",
  "sec1",
  "subtle",
  "zeroize",
@@ -424,6 +451,16 @@ name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys",
+]
 
 [[package]]
 name = "escape-bytes"
@@ -438,12 +475,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca81e6b4777c89fd810c25a4be2b1bd93ea034fbe58e6a75216a34c6b82c539b"
 
 [[package]]
+name = "fastrand"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
 name = "ff"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0b50bfb653653f9ca9095b427bed08ab8d75a137839d9ad64eb11810d5b6393"
 dependencies = [
- "rand_core",
+ "rand_core 0.6.4",
  "subtle",
 ]
 
@@ -464,6 +507,12 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "generic-array"
@@ -490,6 +539,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasip2",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "139ef39800118c7683f2fd3c98c1b23c09ae076556b435f8e9064ae108aaeeec"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasip2",
+ "wasip3",
+]
+
+[[package]]
 name = "gimli"
 version = "0.32.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -502,7 +576,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
 dependencies = [
  "ff",
- "rand_core",
+ "rand_core 0.6.4",
  "subtle",
 ]
 
@@ -514,9 +588,24 @@ checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "foldhash",
+]
+
+[[package]]
+name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+
+[[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hex"
@@ -565,6 +654,12 @@ checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
 dependencies = [
  "cc",
 ]
+
+[[package]]
+name = "id-arena"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
 
 [[package]]
 name = "ident_case"
@@ -648,6 +743,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "leb128fmt"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
+
+[[package]]
 name = "libc"
 version = "0.2.182"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -658,6 +759,12 @@ name = "libm"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
 
 [[package]]
 name = "log"
@@ -812,6 +919,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "proptest"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37566cb3fdacef14c0737f9546df7cfeadbfbc9fef10991038bf5015d0c80532"
+dependencies = [
+ "bit-set",
+ "bit-vec",
+ "bitflags",
+ "num-traits",
+ "rand 0.9.2",
+ "rand_chacha 0.9.0",
+ "rand_xorshift",
+ "regex-syntax",
+ "rusty-fork",
+ "tempfile",
+ "unarray",
+]
+
+[[package]]
+name = "quick-error"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
+
+[[package]]
 name = "quote"
 version = "1.0.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -821,14 +953,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
 name = "rand"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+dependencies = [
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -838,7 +986,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -847,7 +1005,25 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.17",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
+]
+
+[[package]]
+name = "rand_xorshift"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
+dependencies = [
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -869,6 +1045,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a96887878f22d7bad8a3b6dc5b7440e0ada9a245242924394987b21cf2210a4c"
 
 [[package]]
 name = "rfc6979"
@@ -896,10 +1078,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustix"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "146c9e247ccc180c1f61615433868c99f3de3ae256a30a43b49f67c2d9171f34"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys",
+]
+
+[[package]]
 name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "rusty-fork"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc6bf79ff24e648f6da1f8d1f011e9cac26491b619e6b9280f2b47f1774e6ee2"
+dependencies = [
+ "fnv",
+ "quick-error",
+ "tempfile",
+ "wait-timeout",
+]
 
 [[package]]
 name = "schemars"
@@ -1052,7 +1259,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
  "digest",
- "rand_core",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -1089,7 +1296,7 @@ dependencies = [
  "soroban-wasmi",
  "static_assertions",
  "stellar-xdr",
- "wasmparser",
+ "wasmparser 0.116.1",
 ]
 
 [[package]]
@@ -1114,7 +1321,7 @@ dependencies = [
  "ed25519-dalek",
  "elliptic-curve",
  "generic-array",
- "getrandom",
+ "getrandom 0.2.17",
  "hex-literal",
  "hmac",
  "k256",
@@ -1122,8 +1329,8 @@ dependencies = [
  "num-integer",
  "num-traits",
  "p256",
- "rand",
- "rand_chacha",
+ "rand 0.8.5",
+ "rand_chacha 0.3.1",
  "sec1",
  "sha2",
  "sha3",
@@ -1132,7 +1339,7 @@ dependencies = [
  "soroban-wasmi",
  "static_assertions",
  "stellar-strkey",
- "wasmparser",
+ "wasmparser 0.116.1",
 ]
 
 [[package]]
@@ -1175,7 +1382,7 @@ dependencies = [
  "ctor",
  "derive_arbitrary",
  "ed25519-dalek",
- "rand",
+ "rand 0.8.5",
  "rustc_version",
  "serde",
  "serde_json",
@@ -1215,7 +1422,7 @@ dependencies = [
  "base64 0.13.1",
  "stellar-xdr",
  "thiserror",
- "wasmparser",
+ "wasmparser 0.116.1",
 ]
 
 [[package]]
@@ -1238,6 +1445,7 @@ dependencies = [
 name = "soroban-token"
 version = "0.1.0"
 dependencies = [
+ "proptest",
  "soroban-sdk",
 ]
 
@@ -1334,6 +1542,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "tempfile"
+version = "3.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0136791f7c95b1f6dd99f9cc786b91bb81c3800b639b3478e561ddb7be95e5f1"
+dependencies = [
+ "fastrand",
+ "getrandom 0.4.1",
+ "once_cell",
+ "rustix",
+ "windows-sys",
+]
+
+[[package]]
 name = "thiserror"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1391,10 +1612,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
 
 [[package]]
+name = "unarray"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "version_check"
@@ -1403,10 +1636,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
+name = "wait-timeout"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
+
+[[package]]
+name = "wasip2"
+version = "1.0.2+wasi-0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
+dependencies = [
+ "wit-bindgen",
+]
+
+[[package]]
+name = "wasip3"
+version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
+dependencies = [
+ "wit-bindgen",
+]
 
 [[package]]
 name = "wasm-bindgen"
@@ -1454,6 +1714,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-encoder"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
+dependencies = [
+ "leb128fmt",
+ "wasmparser 0.244.0",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
+dependencies = [
+ "anyhow",
+ "indexmap 2.13.0",
+ "wasm-encoder",
+ "wasmparser 0.244.0",
+]
+
+[[package]]
 name = "wasmi_arena"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1477,6 +1759,18 @@ version = "0.116.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a58e28b80dd8340cb07b8242ae654756161f6fc8d0038123d679b7b99964fa50"
 dependencies = [
+ "indexmap 2.13.0",
+ "semver",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
+dependencies = [
+ "bitflags",
+ "hashbrown 0.15.5",
  "indexmap 2.13.0",
  "semver",
 ]
@@ -1547,6 +1841,103 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
 dependencies = [
  "windows-link",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+dependencies = [
+ "wit-bindgen-rust-macro",
+]
+
+[[package]]
+name = "wit-bindgen-core"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
+dependencies = [
+ "anyhow",
+ "heck",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-bindgen-rust"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
+dependencies = [
+ "anyhow",
+ "heck",
+ "indexmap 2.13.0",
+ "prettyplease",
+ "syn",
+ "wasm-metadata",
+ "wit-bindgen-core",
+ "wit-component",
+]
+
+[[package]]
+name = "wit-bindgen-rust-macro"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
+dependencies = [
+ "anyhow",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wit-bindgen-core",
+ "wit-bindgen-rust",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
+dependencies = [
+ "anyhow",
+ "bitflags",
+ "indexmap 2.13.0",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder",
+ "wasm-metadata",
+ "wasmparser 0.244.0",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap 2.13.0",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser 0.244.0",
 ]
 
 [[package]]

--- a/contracts/token/Cargo.toml
+++ b/contracts/token/Cargo.toml
@@ -11,3 +11,4 @@ soroban-sdk = { version = "21.0.0", features = ["alloc"] }
 
 [dev-dependencies]
 soroban-sdk = { version = "21.0.0", features = ["testutils"] }
+proptest = "1"

--- a/contracts/token/tests/fuzz_tests.rs
+++ b/contracts/token/tests/fuzz_tests.rs
@@ -1,0 +1,431 @@
+//! # Fuzz / Property-Based Tests for Token Arithmetic
+//!
+//! This module validates the core arithmetic invariants of the `TokenContract`
+//! using property-based (fuzz) testing via the [`proptest`] crate.
+//!
+//! ## Invariants
+//!
+//! The following invariants **must** hold at all times:
+//!
+//! 1. **Balance–Supply Conservation**
+//!    `∑ balance(account) == total_supply` for every tracked account.
+//!
+//! 2. **Mint Additivity**
+//!    `mint(to, amount)` ⟹ `balance(to)' == balance(to) + amount`
+//!    **and** `total_supply' == total_supply + amount`.
+//!
+//! 3. **Burn Additivity**
+//!    `burn(from, amount)` ⟹ `balance(from)' == balance(from) - amount`
+//!    **and** `total_supply' == total_supply - amount`.
+//!
+//! 4. **Transfer Conservation**
+//!    `transfer(from, to, amount)` ⟹ `total_supply' == total_supply`
+//!    **and** `balance(from)' + balance(to)' == balance(from) + balance(to)`.
+//!
+//! 5. **Non-Negative Balances**
+//!    `balance(account) >= 0` for every account, always.
+//!
+//! 6. **Max-Supply Cap**
+//!    If `max_supply` is set then `total_supply <= max_supply` always.
+//!
+//! 7. **Zero-Amount Rejection**
+//!    `mint(_, 0)`, `burn(_, 0)`, and `transfer(_, _, 0)` must revert.
+//!
+//! 8. **Overflow Protection**
+//!    Operations whose result would overflow `i128` must revert rather than
+//!    wrapping silently.
+
+use proptest::prelude::*;
+use soroban_sdk::{testutils::Address as _, Address, Env, String};
+use soroban_token::{TokenContract, TokenContractClient};
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/// 1 000 000 tokens with 7 decimals.
+const INITIAL_SUPPLY: i128 = 1_000_000_0000000;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/// Create an uncapped token environment with three distinct addresses.
+fn setup_env() -> (Env, TokenContractClient<'static>, Address, Address, Address) {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let id = env.register_contract(None, TokenContract);
+    let client = TokenContractClient::new(&env, &id);
+
+    let admin = Address::generate(&env);
+    let user1 = Address::generate(&env);
+    let user2 = Address::generate(&env);
+
+    client.initialize(
+        &admin,
+        &7u32,
+        &String::from_str(&env, "FuzzToken"),
+        &String::from_str(&env, "FZT"),
+        &INITIAL_SUPPLY,
+        &None,
+    );
+
+    (env, client, admin, user1, user2)
+}
+
+/// Create a capped token environment.
+fn setup_capped_env(
+    initial: i128,
+    cap: i128,
+) -> (Env, TokenContractClient<'static>, Address, Address) {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let id = env.register_contract(None, TokenContract);
+    let client = TokenContractClient::new(&env, &id);
+
+    let admin = Address::generate(&env);
+    let user = Address::generate(&env);
+
+    client.initialize(
+        &admin,
+        &7u32,
+        &String::from_str(&env, "CappedFuzz"),
+        &String::from_str(&env, "CFZ"),
+        &initial,
+        &Some(cap),
+    );
+
+    (env, client, admin, user)
+}
+
+/// **Invariant 1** — sum of all tracked balances == total_supply.
+fn assert_supply_invariant(client: &TokenContractClient, accounts: &[&Address]) {
+    let sum: i128 = accounts.iter().map(|a| client.balance(a)).sum();
+    let supply = client.total_supply();
+    assert_eq!(
+        sum, supply,
+        "INVARIANT VIOLATED: sum of balances ({sum}) != total_supply ({supply})"
+    );
+}
+
+/// **Invariant 5** — every balance >= 0.
+fn assert_non_negative_balances(client: &TokenContractClient, accounts: &[&Address]) {
+    for acct in accounts {
+        let bal = client.balance(acct);
+        assert!(
+            bal >= 0,
+            "INVARIANT VIOLATED: negative balance {bal}"
+        );
+    }
+}
+
+/// **Invariant 6** — total_supply <= max_supply (when a cap exists).
+fn assert_max_supply_invariant(client: &TokenContractClient) {
+    if let Some(cap) = client.max_supply() {
+        let supply = client.total_supply();
+        assert!(
+            supply <= cap,
+            "INVARIANT VIOLATED: total_supply ({supply}) > max_supply ({cap})"
+        );
+    }
+}
+
+// ===========================================================================
+// Property tests
+// ===========================================================================
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(64))]
+
+    // ── Mint ────────────────────────────────────────────────────────────
+
+    /// Invariant 2: mint increases balance and total_supply by exactly `amount`.
+    #[test]
+    fn prop_mint_preserves_balance_and_supply(amount in 1i128..=1_000_000_000_000i128) {
+        let (_, client, admin, user, _) = setup_env();
+        let supply_before = client.total_supply();
+        let bal_before    = client.balance(&user);
+
+        client.mint(&user, &amount);
+
+        prop_assert_eq!(client.balance(&user), bal_before + amount);
+        prop_assert_eq!(client.total_supply(), supply_before + amount);
+        assert_supply_invariant(&client, &[&admin, &user]);
+        assert_non_negative_balances(&client, &[&admin, &user]);
+    }
+
+    /// Multiple sequential mints accumulate correctly.
+    #[test]
+    fn prop_sequential_mints_accumulate(
+        a1 in 1i128..=500_000_000i128,
+        a2 in 1i128..=500_000_000i128,
+        a3 in 1i128..=500_000_000i128,
+    ) {
+        let (_, client, admin, user, _) = setup_env();
+        let supply_before = client.total_supply();
+
+        client.mint(&user, &a1);
+        client.mint(&user, &a2);
+        client.mint(&user, &a3);
+
+        let total_minted = a1 + a2 + a3;
+        prop_assert_eq!(client.balance(&user), total_minted);
+        prop_assert_eq!(client.total_supply(), supply_before + total_minted);
+        assert_supply_invariant(&client, &[&admin, &user]);
+    }
+
+    // ── Burn ────────────────────────────────────────────────────────────
+
+    /// Invariant 3: burn decreases balance and total_supply by exactly `amount`.
+    #[test]
+    fn prop_burn_preserves_balance_and_supply(amount in 1i128..=INITIAL_SUPPLY) {
+        let (_, client, admin, _, _) = setup_env();
+        let supply_before = client.total_supply();
+        let bal_before    = client.balance(&admin);
+
+        client.burn(&admin, &amount);
+
+        prop_assert_eq!(client.balance(&admin), bal_before - amount);
+        prop_assert_eq!(client.total_supply(), supply_before - amount);
+        assert_supply_invariant(&client, &[&admin]);
+        assert_non_negative_balances(&client, &[&admin]);
+    }
+
+    /// Burn followed by an equal mint returns state to the original values.
+    #[test]
+    fn prop_burn_then_mint_roundtrip(amount in 1i128..=INITIAL_SUPPLY) {
+        let (_, client, admin, _, _) = setup_env();
+        let supply_before = client.total_supply();
+        let bal_before    = client.balance(&admin);
+
+        client.burn(&admin, &amount);
+        client.mint(&admin, &amount);
+
+        prop_assert_eq!(client.balance(&admin), bal_before);
+        prop_assert_eq!(client.total_supply(), supply_before);
+    }
+
+    // ── Transfer ────────────────────────────────────────────────────────
+
+    /// Invariant 4: transfer preserves total_supply and the pair-wise sum.
+    #[test]
+    fn prop_transfer_conserves_supply(amount in 1i128..=INITIAL_SUPPLY) {
+        let (_, client, admin, user, _) = setup_env();
+        let supply_before = client.total_supply();
+        let sum_before    = client.balance(&admin) + client.balance(&user);
+
+        client.transfer(&admin, &user, &amount);
+
+        prop_assert_eq!(client.total_supply(), supply_before);
+        prop_assert_eq!(
+            client.balance(&admin) + client.balance(&user),
+            sum_before
+        );
+        assert_supply_invariant(&client, &[&admin, &user]);
+        assert_non_negative_balances(&client, &[&admin, &user]);
+    }
+
+    /// Transfer A → B then B → A returns both balances to their originals.
+    #[test]
+    fn prop_transfer_roundtrip(amount in 1i128..=INITIAL_SUPPLY) {
+        let (_, client, admin, user, _) = setup_env();
+        let admin_bal = client.balance(&admin);
+        let user_bal  = client.balance(&user);
+
+        client.transfer(&admin, &user, &amount);
+        client.transfer(&user, &admin, &amount);
+
+        prop_assert_eq!(client.balance(&admin), admin_bal);
+        prop_assert_eq!(client.balance(&user), user_bal);
+    }
+
+    // ── Sequential mixed operations ─────────────────────────────────────
+
+    /// A random mint → transfer → burn sequence must keep all invariants.
+    #[test]
+    fn prop_mint_transfer_burn_sequence(
+        mint_amt     in 1i128..=500_000_0000000i128,
+        transfer_pct in 1u32..=100u32,
+        burn_pct     in 1u32..=100u32,
+    ) {
+        let (_, client, admin, user1, user2) = setup_env();
+        let accounts = [&admin, &user1, &user2];
+
+        // Step 1 — mint to user1
+        client.mint(&user1, &mint_amt);
+        assert_supply_invariant(&client, &accounts);
+
+        // Step 2 — transfer a percentage of user1's balance to user2
+        let user1_bal = client.balance(&user1);
+        let xfer_amt  = (user1_bal as u128 * transfer_pct as u128 / 100) as i128;
+        if xfer_amt > 0 {
+            client.transfer(&user1, &user2, &xfer_amt);
+            assert_supply_invariant(&client, &accounts);
+        }
+
+        // Step 3 — burn a percentage of admin's balance
+        let admin_bal = client.balance(&admin);
+        let burn_amt  = (admin_bal as u128 * burn_pct as u128 / 100) as i128;
+        if burn_amt > 0 {
+            client.burn(&admin, &burn_amt);
+            assert_supply_invariant(&client, &accounts);
+        }
+
+        assert_non_negative_balances(&client, &accounts);
+    }
+
+    /// Repeated small operations across multiple accounts preserve the invariant.
+    #[test]
+    fn prop_many_transfers_preserve_invariant(
+        a1 in 1i128..=100_0000000i128,
+        a2 in 1i128..=100_0000000i128,
+        a3 in 1i128..=100_0000000i128,
+    ) {
+        let (_, client, admin, user1, user2) = setup_env();
+        let accounts = [&admin, &user1, &user2];
+
+        // Distribute from admin to multiple users
+        client.transfer(&admin, &user1, &a1);
+        client.transfer(&admin, &user2, &a2);
+        assert_supply_invariant(&client, &accounts);
+
+        // user1 → user2
+        let user1_bal = client.balance(&user1);
+        let xfer = a3.min(user1_bal);
+        if xfer > 0 {
+            client.transfer(&user1, &user2, &xfer);
+        }
+        assert_supply_invariant(&client, &accounts);
+
+        // user2 → admin (return some tokens)
+        let user2_bal = client.balance(&user2);
+        if user2_bal > 0 {
+            client.transfer(&user2, &admin, &user2_bal);
+        }
+
+        assert_supply_invariant(&client, &accounts);
+        assert_non_negative_balances(&client, &accounts);
+    }
+
+    // ── Max-supply enforcement ──────────────────────────────────────────
+
+    /// Invariant 6: minting within the remaining cap succeeds and respects the cap.
+    #[test]
+    fn prop_mint_within_cap_preserves_invariant(amount in 1i128..=500_0000000i128) {
+        let initial = 500_0000000i128;
+        let cap     = 1_000_0000000i128;
+        let (_, client, admin, user) = setup_capped_env(initial, cap);
+
+        let remaining = cap - client.total_supply();
+        prop_assume!(amount <= remaining);
+
+        client.mint(&user, &amount);
+
+        assert_max_supply_invariant(&client);
+        assert_supply_invariant(&client, &[&admin, &user]);
+    }
+}
+
+// ===========================================================================
+// Zero-amount edge cases (Invariant 7)
+// ===========================================================================
+
+#[test]
+#[should_panic(expected = "amount must be positive")]
+fn test_zero_amount_mint_rejected() {
+    let (_, client, _, user, _) = setup_env();
+    client.mint(&user, &0i128);
+}
+
+#[test]
+#[should_panic(expected = "amount must be positive")]
+fn test_zero_amount_burn_rejected() {
+    let (_, client, admin, _, _) = setup_env();
+    client.burn(&admin, &0i128);
+}
+
+#[test]
+#[should_panic(expected = "amount must be positive")]
+fn test_zero_amount_transfer_rejected() {
+    let (_, client, admin, user, _) = setup_env();
+    client.transfer(&admin, &user, &0i128);
+}
+
+#[test]
+#[should_panic(expected = "amount must be positive")]
+fn test_negative_amount_mint_rejected() {
+    let (_, client, _, user, _) = setup_env();
+    client.mint(&user, &-1i128);
+}
+
+#[test]
+#[should_panic(expected = "amount must be positive")]
+fn test_negative_amount_burn_rejected() {
+    let (_, client, admin, _, _) = setup_env();
+    client.burn(&admin, &-1i128);
+}
+
+#[test]
+#[should_panic(expected = "amount must be positive")]
+fn test_negative_amount_transfer_rejected() {
+    let (_, client, admin, user, _) = setup_env();
+    client.transfer(&admin, &user, &-1i128);
+}
+
+// ===========================================================================
+// i128 overflow / underflow (Invariant 8)
+// ===========================================================================
+
+#[test]
+#[should_panic]
+fn test_mint_i128_overflow() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let id = env.register_contract(None, TokenContract);
+    let client = TokenContractClient::new(&env, &id);
+    let admin = Address::generate(&env);
+    let user  = Address::generate(&env);
+
+    // Start near i128::MAX so the next mint overflows total_supply.
+    client.initialize(
+        &admin,
+        &7u32,
+        &String::from_str(&env, "OverflowToken"),
+        &String::from_str(&env, "OVF"),
+        &(i128::MAX - 1),
+        &None,
+    );
+
+    // total_supply is (i128::MAX − 1); minting 2 overflows.
+    client.mint(&user, &2i128);
+}
+
+#[test]
+#[should_panic(expected = "insufficient balance to burn")]
+fn test_burn_underflow_rejected() {
+    let (_, client, _, user, _) = setup_env();
+    // user has 0 balance — burning 1 must revert.
+    client.burn(&user, &1i128);
+}
+
+#[test]
+#[should_panic(expected = "insufficient balance")]
+fn test_transfer_underflow_rejected() {
+    let (_, client, _, user1, user2) = setup_env();
+    // user1 has 0 balance — transferring 1 must revert.
+    client.transfer(&user1, &user2, &1i128);
+}
+
+#[test]
+#[should_panic(expected = "mint would exceed max_supply")]
+fn test_mint_exceeds_max_supply_rejected() {
+    let initial = 500_0000000i128;
+    let cap     = 1_000_0000000i128;
+    let (_, client, _, user) = setup_capped_env(initial, cap);
+
+    // Remaining capacity is 500_0000000 — minting 1 more overflows the cap.
+    client.mint(&user, &(500_0000001i128));
+}


### PR DESCRIPTION
## Summary
Closes #6

Adds property-based (fuzz) tests for `mint`, `burn`, and `transfer` using
the `proptest` crate. Each property test runs 64 randomised cases.

## Changes

- **`contracts/token/Cargo.toml`** — added `proptest = "1"` dev-dependency.
- **`contracts/token/tests/fuzz_tests.rs`** — new integration test file
  containing 19 tests (10 property-based, 9 deterministic edge-case).

## Test coverage

| Area | Tests |
|------|-------|
| Mint invariants | `prop_mint_preserves_balance_and_supply`, `prop_sequential_mints_accumulate` |
| Burn invariants | `prop_burn_preserves_balance_and_supply`, `prop_burn_then_mint_roundtrip` |
| Transfer invariants | `prop_transfer_conserves_supply`, `prop_transfer_roundtrip` |
| Sequential operations | `prop_mint_transfer_burn_sequence`, `prop_many_transfers_preserve_invariant` |
| Max-supply cap | `prop_mint_within_cap_preserves_invariant`, `test_mint_exceeds_max_supply_rejected` |
| Zero/negative amounts | 6 `#[should_panic]` tests for mint, burn, and transfer |
| i128 overflow/underflow | `test_mint_i128_overflow`, `test_burn_underflow_rejected`, `test_transfer_underflow_rejected` |

## Documented invariants

The following invariants are documented in the module header and enforced by
shared helper assertions (`assert_supply_invariant`, `assert_non_negative_balances`,
`assert_max_supply_invariant`):

1. **Balance–Supply Conservation** — `Σ balance(account) == total_supply`
2. **Mint Additivity** — balance and supply increase by exactly `amount`
3. **Burn Additivity** — balance and supply decrease by exactly `amount`
4. **Transfer Conservation** — total_supply unchanged; sender + receiver sum unchanged
5. **Non-Negative Balances** — `balance(account) >= 0` always
6. **Max-Supply Cap** — `total_supply <= max_supply` when a cap exists
7. **Zero-Amount Rejection** — `mint(0)`, `burn(0)`, `transfer(0)` revert
8. **Overflow Protection** — arithmetic overflow of `i128` reverts

<img width="1039" height="442" alt="Screenshot from 2026-02-20 08-47-22" src="https://github.com/user-attachments/assets/01051c53-63d1-4198-aab0-efd6009fe498" />


## How to run

```bash
cargo test -p soroban-token --test fuzz_tests