### PR TITLE
Add Stellar Expert Block Explorer Links

### DIFF
--- a/frontend/app/dashboard/[contractId]/TokenDashboard.tsx
+++ b/frontend/app/dashboard/[contractId]/TokenDashboard.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState, useMemo, useCallback } from "react";
 import { Copy, Check, ArrowUpDown, AlertCircle, Loader2, Download } from "lucide-react";
 import {
   truncateAddress,
+  getStellarExpertUrl,
   type TokenInfo,
   type TokenHolder,
   type SupplyBreakdown,
@@ -204,8 +205,16 @@ function HoldersTable({ holders }: { holders: TokenHolder[] }) {
               >
                 <td className="px-4 py-3 font-mono text-xs text-stellar-300">
                   <div className="flex items-center gap-2">
-                    <span className="hidden sm:inline">{holder.address}</span>
-                    <span className="sm:hidden">{truncateAddress(holder.address, 6)}</span>
+                    <a
+                      href={getStellarExpertUrl(holder.address, 'account')}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="hover:text-stellar-300 hover:underline"
+                      title="View on Stellar Expert"
+                    >
+                      <span className="hidden sm:inline">{holder.address}</span>
+                      <span className="sm:hidden">{truncateAddress(holder.address, 6)}</span>
+                    </a>
                     <CopyButton value={holder.address} label="Copy wallet address" />
                   </div>
                 </td>
@@ -295,10 +304,16 @@ export default function TokenDashboard({ contractId }: { contractId: string }) {
           <span className="text-stellar-400">({tokenInfo.symbol})</span>
         </h1>
         <div className="mt-2 flex flex-wrap items-center gap-2 text-sm text-gray-400">
-          <span className="font-mono text-xs">
+          <a
+            href={getStellarExpertUrl(contractId, 'contract')}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="font-mono text-xs text-stellar-400 hover:text-stellar-300 hover:underline"
+            title="View on Stellar Expert"
+          >
             <span className="hidden md:inline">{contractId}</span>
             <span className="md:hidden">{truncateAddress(contractId, 8)}</span>
-          </span>
+          </a>
           <CopyButton value={contractId} label="Copy contract ID" />
         </div>
       </div>

--- a/frontend/lib/stellar.ts
+++ b/frontend/lib/stellar.ts
@@ -609,3 +609,21 @@ export async function submitTransaction(signedXdr: string): Promise<string> {
 
   return result.hash;
 }
+
+// ---------------------------------------------------------------------------
+// Stellar Expert URL helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Generate a Stellar Expert explorer URL for a contract ID or public key
+ */
+export function getStellarExpertUrl(address: string, type: 'contract' | 'account' | 'tx' = 'account'): string {
+  const network = 'mainnet'; // Default to mainnet
+  if (type === 'tx') {
+    return `https://stellar.expert/explorer/${network}/tx/${address}`;
+  }
+  if (type === 'contract') {
+    return `https://stellar.expert/explorer/${network}/contract/${address}`;
+  }
+  return `https://stellar.expert/explorer/${network}/account/${address}`;
+}


### PR DESCRIPTION
## Summary
Adds clickable links to stellar.expert for contract IDs and wallet addresses in the token dashboard.

## Changes
- Added `getStellarExpertUrl()` helper function in `lib/stellar.ts`
- Updated TokenDashboard to link contract ID to stellar.expert/contract/...
- Updated TokenDashboard to link holder addresses to stellar.expert/account/...

## Testing
- Code compiles successfully
- Links follow the pattern: `https://stellar.expert/explorer/mainnet/contract/{id}`

## Related Bounty
This implements the feature requested in soropad/launchpad#49