### PR TITLE
feat(dashboard): aggregate token holders from Horizon

### DIFF
--- a/frontend/lib/stellar.ts
+++ b/frontend/lib/stellar.ts
@@ -462,49 +462,84 @@ export async function fetchTokenBalance(
 export async function fetchTopHolders(
   contractId: string,
   config: NetworkConfig,
-  _symbol?: string,
-  _issuer?: string,
+  symbolHint?: string,
+  issuerHint?: string,
   limit = 10,
 ): Promise<TokenHolder[]> {
   try {
     const horizon = new StellarSdk.Horizon.Server(config.horizonUrl);
+    const symbol =
+      symbolHint ??
+      decodeString(await simulateCall(contractId, "symbol", config));
+    const decimals =
+      decodeU32(await simulateCall(contractId, "decimals", config));
 
-    if (_symbol && _issuer) {
-      const asset = new StellarSdk.Asset(_symbol, _issuer);
-      const { records } = await horizon
-        .accounts()
-        .forAsset(asset)
-        .limit(limit)
-        .order("desc")
-        .call();
+    let issuer = issuerHint;
+    if (!issuer) {
+      // Resolve issuer for this asset code from Horizon stats.
+      // If multiple issuers exist for same code, prefer one with largest supply.
+      const assetsPage = await horizon.assets().forCode(symbol).limit(200).call();
+      if (assetsPage.records.length === 0) {
+        return [];
+      }
+      const getAssetAmount = (record: unknown): string => {
+        const raw = (record as { amount?: unknown }).amount;
+        return typeof raw === "string" ? raw : "0";
+      };
+      issuer = assetsPage.records
+        .slice()
+        .sort(
+          (a, b) =>
+            parseFloat(getAssetAmount(b)) - parseFloat(getAssetAmount(a)),
+        )[0]
+        .asset_issuer;
+    }
 
-      let total = BigInt(0);
-      const parsed = records.map((acc) => {
+    const asset = new StellarSdk.Asset(symbol, issuer);
+    const [holdersPage, assetStats] = await Promise.all([
+      horizon.accounts().forAsset(asset).limit(limit).order("desc").call(),
+      horizon.assets().forCode(symbol).forIssuer(issuer).limit(1).call(),
+    ]);
+
+    const toRawAmount = (amount: string, tokenDecimals: number): bigint => {
+      const [wholePart, fracPart = ""] = amount.split(".");
+      const normalizedFrac = fracPart
+        .padEnd(tokenDecimals, "0")
+        .slice(0, tokenDecimals);
+      return BigInt(`${wholePart}${normalizedFrac}`);
+    };
+
+    const totalSupplyRaw =
+      assetStats.records.length > 0
+        ? toRawAmount(
+            (assetStats.records[0] as { amount?: string }).amount ?? "0",
+            decimals,
+          )
+        : BigInt(0);
+
+    const parsed = holdersPage.records
+      .map((acc) => {
         const bal = acc.balances.find(
           (b) =>
             "asset_code" in b &&
-            b.asset_code === _symbol &&
+            b.asset_code === symbol &&
             "asset_issuer" in b &&
-            b.asset_issuer === _issuer,
+            b.asset_issuer === issuer,
         );
-        const raw = BigInt(
-          Math.round(parseFloat(bal ? bal.balance : "0") * 1e7),
-        );
-        total += raw;
-        return { address: acc.account_id, rawBalance: raw };
-      });
+        const rawBalance = toRawAmount(bal ? bal.balance : "0", decimals);
+        return { address: acc.account_id, rawBalance };
+      })
+      .filter((row) => row.rawBalance > BigInt(0))
+      .sort((a, b) => (a.rawBalance > b.rawBalance ? -1 : a.rawBalance < b.rawBalance ? 1 : 0));
 
-      return parsed.map(({ address, rawBalance }) => ({
-        address,
-        balance: (Number(rawBalance) / 1e7).toFixed(7),
-        sharePercent:
-          total > BigInt(0)
-            ? Number((rawBalance * BigInt(10000)) / total) / 100
-            : 0,
-      }));
-    }
-
-    return [];
+    return parsed.map(({ address, rawBalance }) => ({
+      address,
+      balance: (Number(rawBalance) / 10 ** decimals).toFixed(decimals),
+      sharePercent:
+        totalSupplyRaw > BigInt(0)
+          ? Number((rawBalance * BigInt(10000)) / totalSupplyRaw) / 100
+          : 0,
+    }));
   } catch {
     return [];
   }


### PR DESCRIPTION
## Summary
- Implemented token holder leaderboard aggregation in `frontend/lib/stellar.ts` using Horizon asset-account data.
- Added issuer resolution when only token code is known by selecting the highest-supply issuer from Horizon asset stats.
- Computed holder `% of supply` from Horizon total supply and returned sorted `{ address, balance, sharePercent }` rows for dashboard consumption.

## Implementation Notes
- Primary file changed: `frontend/lib/stellar.ts` (`fetchTopHolders`).
- Behavior:
  - Resolves token `symbol` and `decimals` from contract if hints are not provided.
  - Resolves issuer from Horizon (`/assets?asset_code=...`) when not provided.
  - Fetches holders from Horizon asset accounts endpoint and computes percentages from asset total supply.
- Reliability note: Added decimal-string -> bigint normalization helper to avoid floating-point precision loss in raw amount math.

## Validation
- `pnpm install --frozen-lockfile` -> pass
- `pnpm type-check` -> pass
- `pnpm test -- --runInBand` -> pass (5 suites, 66 tests)
- `pnpm build` -> pass
- `pnpm lint .` -> pass with pre-existing warnings (2 warnings, 0 errors):
  - `app/my-account/PersonalDashboard.tsx` unused var
  - `lib/deployments.ts` unused type import
- Merge conflict dry-run against `upstream/master`: pass (`Automatic merge went well; stopped before committing as requested`)

## Repro Steps for Maintainer
1. Run `pnpm install` in `frontend/`.
2. Open dashboard for a token contract with a classic asset representation available in Horizon.
3. Confirm holder table displays sorted holder balances and `% share` values; export CSV should reflect same table data.

## Risks / Follow-ups
- If multiple issuers share the same asset code, current fallback chooses highest reported supply from Horizon stats; this is pragmatic but heuristic.
- For pure Soroban-native tokens without

Closes #106 