### PR TITLE
feat(i18n): add multi-language support for Spanish, French, and Chinese

### DIFF
--- a/frontend/app/components/LanguageSwitcher.tsx
+++ b/frontend/app/components/LanguageSwitcher.tsx
@@ -2,42 +2,28 @@
 
 import { useState } from "react";
 import { Globe, ChevronDown } from "lucide-react";
+import { useLocale } from "../providers/LocaleProvider";
 
-const SUPPORTED_LOCALES = [{ code: "en", label: "English" }] as const;
+const SUPPORTED_LOCALES = [
+  { code: "en" as const, label: "English" },
+  { code: "es" as const, label: "Español" },
+  { code: "fr" as const, label: "Français" },
+  { code: "zh" as const, label: "中文" },
+];
 
 type LocaleCode = (typeof SUPPORTED_LOCALES)[number]["code"];
 
-const STORAGE_KEY = "soropad:locale";
-
-function getInitialLocale(): LocaleCode {
-  try {
-    const stored = localStorage.getItem(STORAGE_KEY) as LocaleCode | null;
-    if (stored && SUPPORTED_LOCALES.some((l) => l.code === stored)) {
-      return stored;
-    }
-  } catch {
-    // localStorage unavailable
-  }
-  return "en";
-}
-
 export function LanguageSwitcher() {
-  const [currentLocale, setCurrentLocale] =
-    useState<LocaleCode>(getInitialLocale);
+  const { locale, setLocale } = useLocale();
   const [isOpen, setIsOpen] = useState(false);
 
   const handleSelect = (code: LocaleCode) => {
-    setCurrentLocale(code);
+    setLocale(code);
     setIsOpen(false);
-    try {
-      localStorage.setItem(STORAGE_KEY, code);
-    } catch {
-      // localStorage unavailable
-    }
   };
 
   const currentLabel =
-    SUPPORTED_LOCALES.find((l) => l.code === currentLocale)?.label ?? "English";
+    SUPPORTED_LOCALES.find((l) => l.code === locale)?.label ?? "English";
 
   return (
     <div className="relative">
@@ -65,20 +51,20 @@ export function LanguageSwitcher() {
             aria-label="Available languages"
             className="absolute left-0 mt-2 w-36 origin-top-left rounded-xl border border-white/10 bg-void-800 p-1 shadow-2xl z-50"
           >
-            {SUPPORTED_LOCALES.map((locale) => (
-              <li key={locale.code}>
+            {SUPPORTED_LOCALES.map((l) => (
+              <li key={l.code}>
                 <button
                   type="button"
                   role="option"
-                  aria-selected={locale.code === currentLocale}
-                  onClick={() => handleSelect(locale.code)}
+                  aria-selected={l.code === locale}
+                  onClick={() => handleSelect(l.code)}
                   className={`flex w-full items-center gap-2 rounded-lg px-3 py-2 text-left text-sm transition-colors ${
-                    locale.code === currentLocale
+                    l.code === locale
                       ? "bg-stellar-500/10 text-stellar-400"
                       : "text-gray-400 hover:bg-white/5 hover:text-white"
                   }`}
                 >
-                  {locale.label}
+                  {l.label}
                 </button>
               </li>
             ))}

--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -5,10 +5,10 @@ import { WalletProvider } from "./providers/WalletProvider";
 import { SettingsProvider } from "./providers/SettingsProvider";
 import { NetworkProvider } from "./providers/NetworkProvider";
 import { AccessibilityProvider } from "./providers/AccessibilityProvider";
+import { LocaleProvider } from "./providers/LocaleProvider";
 import { I18nProvider } from "./providers/I18nProvider";
 import { Navbar } from "./components/Navbar";
 import { MainnetWarning } from "./components/MainnetWarning";
-import messages from "../messages/en.json";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -47,38 +47,40 @@ export default function RootLayout({
         <a href="#main-content" className="skip-link">
           Skip to main content
         </a>
-        <I18nProvider locale="en" messages={messages}>
-          <NetworkProvider>
-            <SettingsProvider>
-              <WalletProvider>
-                <AccessibilityProvider>
-                  <Navbar />
-                  <MainnetWarning />
-                  <main id="main-content" className="pt-16" role="main">
-                    {children}
-                  </main>
-                  <footer
-                    role="contentinfo"
-                    className="border-t border-white/5 py-8 text-center text-sm text-gray-500"
-                  >
-                    <p>
-                      Built for the{" "}
-                      <a
-                        href="https://www.drips.network/wave"
-                        className="text-stellar-400 hover:underline"
-                        target="_blank"
-                        rel="noopener noreferrer"
-                      >
-                        Stellar Wave Program
-                      </a>{" "}
-                      · MIT License
-                    </p>
-                  </footer>
-                </AccessibilityProvider>
-              </WalletProvider>
-            </SettingsProvider>
-          </NetworkProvider>
-        </I18nProvider>
+        <LocaleProvider>
+          <I18nProvider>
+            <NetworkProvider>
+              <SettingsProvider>
+                <WalletProvider>
+                  <AccessibilityProvider>
+                    <Navbar />
+                    <MainnetWarning />
+                    <main id="main-content" className="pt-16" role="main">
+                      {children}
+                    </main>
+                    <footer
+                      role="contentinfo"
+                      className="border-t border-white/5 py-8 text-center text-sm text-gray-500"
+                    >
+                      <p>
+                        Built for the{" "}
+                        <a
+                          href="https://www.drips.network/wave"
+                          className="text-stellar-400 hover:underline"
+                          target="_blank"
+                          rel="noopener noreferrer"
+                        >
+                          Stellar Wave Program
+                        </a>{" "}
+                        · MIT License
+                      </p>
+                    </footer>
+                  </AccessibilityProvider>
+                </WalletProvider>
+              </SettingsProvider>
+            </NetworkProvider>
+          </I18nProvider>
+        </LocaleProvider>
       </body>
     </html>
   );

--- a/frontend/app/providers/I18nProvider.tsx
+++ b/frontend/app/providers/I18nProvider.tsx
@@ -1,15 +1,32 @@
 "use client";
 
-import { ReactNode } from "react";
+import { ReactNode, useEffect, useState } from "react";
 import { NextIntlClientProvider, AbstractIntlMessages } from "next-intl";
+import { useLocale } from "./LocaleProvider";
 
 interface I18nProviderProps {
   children: ReactNode;
-  locale: string;
-  messages: AbstractIntlMessages;
 }
 
-export function I18nProvider({ children, locale, messages }: I18nProviderProps) {
+export function I18nProvider({ children }: I18nProviderProps) {
+  const { locale, messages: contextMessages } = useLocale();
+  const [messages, setMessages] = useState<AbstractIntlMessages>({});
+  const [isClientReady, setIsClientReady] = useState(false);
+
+  useEffect(() => {
+    setIsClientReady(true);
+  }, []);
+
+  useEffect(() => {
+    if (contextMessages && Object.keys(contextMessages).length > 0) {
+      setMessages(contextMessages);
+    }
+  }, [contextMessages]);
+
+  if (!isClientReady) {
+    return <>{children}</>;
+  }
+
   return (
     <NextIntlClientProvider locale={locale} messages={messages}>
       {children}

--- a/frontend/app/providers/LocaleProvider.tsx
+++ b/frontend/app/providers/LocaleProvider.tsx
@@ -1,0 +1,98 @@
+"use client";
+
+import {
+  createContext,
+  useContext,
+  useState,
+  useEffect,
+  useSyncExternalStore,
+  ReactNode,
+} from "react";
+import { AbstractIntlMessages } from "next-intl";
+
+type Locale = "en" | "es" | "fr" | "zh";
+
+interface LocaleContextType {
+  locale: Locale;
+  messages: AbstractIntlMessages;
+  setLocale: (locale: Locale) => void;
+}
+
+const SUPPORTED_LOCALES: Locale[] = ["en", "es", "fr", "zh"];
+
+const STORAGE_KEY = "soropad:locale";
+
+const defaultMessages: AbstractIntlMessages = {};
+
+const LocaleContext = createContext<LocaleContextType>({
+  locale: "en",
+  messages: defaultMessages,
+  setLocale: () => {},
+});
+
+export function useLocale() {
+  return useContext(LocaleContext);
+}
+
+function getInitialLocale(): Locale {
+  if (typeof window === "undefined") return "en";
+  try {
+    const stored = localStorage.getItem(STORAGE_KEY) as Locale | null;
+    if (stored && SUPPORTED_LOCALES.includes(stored)) {
+      return stored;
+    }
+  } catch {}
+  return "en";
+}
+
+async function loadMessages(locale: Locale): Promise<AbstractIntlMessages> {
+  switch (locale) {
+    case "es":
+      return (await import("../../messages/es.json")).default;
+    case "fr":
+      return (await import("../../messages/fr.json")).default;
+    case "zh":
+      return (await import("../../messages/zh.json")).default;
+    default:
+      return (await import("../../messages/en.json")).default;
+  }
+}
+
+interface LocaleProviderProps {
+  children: ReactNode;
+}
+
+export function LocaleProvider({ children }: LocaleProviderProps) {
+  const [locale, setLocaleState] = useState<Locale>("en");
+  const [messages, setMessages] = useState<AbstractIntlMessages>(defaultMessages);
+  const [isLoaded, setIsLoaded] = useState(false);
+
+  useEffect(() => {
+    const initialLocale = getInitialLocale();
+    setLocaleState(initialLocale);
+    loadMessages(initialLocale).then((msgs) => {
+      setMessages(msgs);
+      setIsLoaded(true);
+    });
+  }, []);
+
+  useEffect(() => {
+    if (!isLoaded) return;
+    loadMessages(locale).then((msgs) => {
+      setMessages(msgs);
+    });
+  }, [locale, isLoaded]);
+
+  const setLocale = (newLocale: Locale) => {
+    setLocaleState(newLocale);
+    try {
+      localStorage.setItem(STORAGE_KEY, newLocale);
+    } catch {}
+  };
+
+  return (
+    <LocaleContext.Provider value={{ locale, messages, setLocale }}>
+      {children}
+    </LocaleContext.Provider>
+  );
+}

--- a/frontend/lib/i18n.ts
+++ b/frontend/lib/i18n.ts
@@ -1,6 +1,6 @@
 import { getRequestConfig } from "next-intl/server";
 
-export const locales = ["en"] as const;
+export const locales = ["en", "es", "fr", "zh"] as const;
 export const defaultLocale = "en" as const;
 
 export type Locale = (typeof locales)[number];

--- a/frontend/messages/es.json
+++ b/frontend/messages/es.json
@@ -1,0 +1,159 @@
+{
+  "common": {
+    "loading": "Cargando...",
+    "error": "Error",
+    "success": "Éxito",
+    "cancel": "Cancelar",
+    "save": "Guardar",
+    "back": "Atrás",
+    "continue": "Continuar",
+    "view": "Ver",
+    "close": "Cerrar",
+    "submit": "Enviar",
+    "reset": "Reiniciar",
+    "settings": "Configuración",
+    "check": "Verificar"
+  },
+  "navigation": {
+    "deploy": "Desplegar",
+    "dashboard": "Panel",
+    "allowances": "Asignaciones",
+    "myAccount": "Mi Cuenta",
+    "skipToContent": "Saltar al contenido principal"
+  },
+  "home": {
+    "badge": "Construido en Stellar Soroban",
+    "title": "Lanza Tu Token",
+    "titleHighlight": "En Minutos",
+    "description": "SoroPad es un launchpad de código abierto para desplegar tokens compatibles con SEP-41 en Soroban — con calendarios de vencimiento, controles de administrador y un panel en tiempo real. No se requiere código de smart contract.",
+    "deployButton": "Desplegar un Token",
+    "githubButton": "Ver en GitHub",
+    "features": {
+      "deploy": {
+        "icon": "🪙",
+        "title": "Despliegue con Un Clic",
+        "description": "Rellena un formulario, firma con Freighter, y tu token SEP-41 estará vivo en Soroban."
+      },
+      "vesting": {
+        "icon": "🔒",
+        "title": "Vencimiento y Controles",
+        "description": "Cliff + vencimiento lineal por wallet. Mint, burn y congelación con controles de administrador."
+      },
+      "dashboard": {
+        "icon": "📊",
+        "title": "Panel en Vivo",
+        "description": "Métricas de suministro, tabla de holders, progreso de vencimiento — todo en tiempo real."
+      }
+    }
+  },
+  "deploy": {
+    "title": "Despliega Tu",
+    "titleHighlight": "Token Soroban",
+    "description": "Lanza un token compatible con SEP-41 en minutos. Configura tu metadatos, suministro y gobernanza, luego despliega a la red Stellar.",
+    "steps": {
+      "metadata": "Metadatos",
+      "supply": "Suministro",
+      "admin": "Administrador",
+      "review": "Revisar"
+    },
+    "stepIndicator": "Paso {current}: {name}",
+    "metadata": {
+      "title": "Metadatos del Token",
+      "description": "Define la identidad básica de tu token.",
+      "tokenName": "Nombre del Token",
+      "tokenNamePlaceholder": "ej. Mi Stellar Token",
+      "symbol": "Símbolo",
+      "symbolPlaceholder": "ej. MYTOK",
+      "decimals": "Decimales",
+      "decimalsPlaceholder": "El valor predeterminado es 7",
+      "descriptionLabel": "Descripción (opcional)",
+      "descriptionPlaceholder": "Descripción corta para wallets/explorers",
+      "logoUrl": "URL del Logo (opcional)",
+      "logoUrlPlaceholder": "https://.../logo.png",
+      "website": "Sitio Web (opcional)",
+      "websitePlaceholder": "https://example.com",
+      "twitter": "Twitter (opcional)",
+      "twitterPlaceholder": "@proyecto o https://twitter.com/manejador",
+      "discord": "Discord (opcional)",
+      "discordPlaceholder": "Invitación a Discord o manejador"
+    },
+    "supply": {
+      "title": "Configuración de Suministro",
+      "description": "Establece el suministro inicial y máximo de tu token.",
+      "initialSupply": "Suministro Inicial",
+      "initialSupplyPlaceholder": "ej. 1000000",
+      "maxSupply": "Suministro Máximo (Opcional)",
+      "maxSupplyPlaceholder": "Dejar vacío para ilimitado"
+    },
+    "admin": {
+      "title": "Administración",
+      "description": "Especifica la dirección administrativa para este token.",
+      "adminAddress": "Dirección del Administrador (Clave Pública Stellar)",
+      "adminAddressPlaceholder": "ej. G...",
+      "warning": "El administrador tiene autoridad para mintear más tokens, cambiar metadatos del token y gestionar otras configuraciones administrativas. Asegúrate de tener acceso a esta cuenta."
+    },
+    "review": {
+      "title": "Revisar y Desplegar",
+      "description": "Revisa la configuración de tu token antes de desplegar.",
+      "tokenDetails": "Detalles del Token",
+      "supplyDetails": "Detalles del Suministro",
+      "adminDetails": "Detalles del Administrador",
+      "readyMessage": "La transacción está lista para firmar"
+    },
+    "buttons": {
+      "deployToken": "Desplegar Token"
+    },
+    "validation": {
+      "nameRequired": "El nombre del token es requerido",
+      "nameTooLong": "Nombre demasiado largo",
+      "symbolRequired": "El símbolo es requerido",
+      "symbolTooLong": "Símbolo demasiado largo",
+      "initialSupplyMin": "El suministro inicial debe ser al menos 1",
+      "maxSupplyMin": "El suministro máximo debe ser al menos 1",
+      "invalidPublicKey": "Clave pública Stellar inválida",
+      "initialExceedsMax": "El suministro inicial no puede exceder el suministro máximo"
+    }
+  },
+  "dashboard": {
+    "title": "Panel del Token",
+    "description": "Ingresa el ID de contrato de un token desplegado para ver métricas de suministro, distribución de holders y más.",
+    "searchPlaceholder": "CABC123...XYZ (ID de contrato)",
+    "searchLabel": "ID de Contrato",
+    "viewMyAccount": "Ver Mi Cuenta",
+    "errors": {
+      "emptyContract": "Por favor ingresa un ID de contrato.",
+      "invalidFormat": "Formato de ID de contrato inválido. Se espera una dirección Stellar de 56 caracteres."
+    }
+  },
+  "settings": {
+    "title": "Configuración de Red",
+    "description": "Configura URLs personalizadas de Soroban RPC y Horizon. Los cambios se guardan en tu navegador y persisten entre sesiones.",
+    "rpcUrl": "URL de Soroban RPC",
+    "horizonUrl": "URL de Horizon",
+    "resetToDefaults": "Restablecer valores predeterminados",
+    "validation": {
+      "invalidUrl": "Ingresa una URL HTTP o HTTPS válida.",
+      "unreachable": "No se pudo alcanzar esta URL. Por favor verifica e intenta de nuevo."
+    }
+  },
+  "network": {
+    "testnet": "Testnet",
+    "mainnet": "Mainnet"
+  },
+  "wallet": {
+    "connect": "Conectar Wallet",
+    "disconnect": "Desconectar",
+    "connecting": "Conectando..."
+  },
+  "footer": {
+    "builtFor": "Construido para el",
+    "stellarWave": "Programa Stellar Wave",
+    "license": "Licencia MIT"
+  },
+  "accessibility": {
+    "loading": "Cargando",
+    "openMenu": "Abrir menú",
+    "closeMenu": "Cerrar menú",
+    "closeSettings": "Cerrar configuración"
+  }
+}

--- a/frontend/messages/fr.json
+++ b/frontend/messages/fr.json
@@ -1,0 +1,159 @@
+{
+  "common": {
+    "loading": "Chargement...",
+    "error": "Erreur",
+    "success": "Succès",
+    "cancel": "Annuler",
+    "save": "Enregistrer",
+    "back": "Retour",
+    "continue": "Continuer",
+    "view": "Voir",
+    "close": "Fermer",
+    "submit": "Soumettre",
+    "reset": "Réinitialiser",
+    "settings": "Paramètres",
+    "check": "Vérifier"
+  },
+  "navigation": {
+    "deploy": "Déployer",
+    "dashboard": "Tableau de bord",
+    "allowances": "Allocations",
+    "myAccount": "Mon Compte",
+    "skipToContent": "Aller au contenu principal"
+  },
+  "home": {
+    "badge": "Construit sur Stellar Soroban",
+    "title": "Lancez Votre Token",
+    "titleHighlight": "En Minutes",
+    "description": "SoroPad est un launchpad open-source pour déployer des tokens conformes SEP-41 sur Soroban — avec des calendriers de vesting, des contrôles administrateur et un tableau de bord en temps réel. Pas de code smart-contract requis.",
+    "deployButton": "Déployer un Token",
+    "githubButton": "Voir sur GitHub",
+    "features": {
+      "deploy": {
+        "icon": "🪙",
+        "title": "Déploiement en Un Clic",
+        "description": "Remplissez un formulaire, signez avec Freighter, et votre token SEP-41 est actif sur Soroban."
+      },
+      "vesting": {
+        "icon": "🔒",
+        "title": "Vesting et Contrôles",
+        "description": "Cliff + vesting linéaire par wallet. Mint, burn et gel avec contrôles administrateur."
+      },
+      "dashboard": {
+        "icon": "📊",
+        "title": "Tableau de Bord en Direct",
+        "description": "Métriques d'approvisionnement, tableau des holders, progression du vesting — tout en temps réel."
+      }
+    }
+  },
+  "deploy": {
+    "title": "Déployez Votre",
+    "titleHighlight": "Token Soroban",
+    "description": "Lancez un token production-readyConforme SEP-41 en minutes. Configurez vos métadonnées, approvisionnement et gouvernance, puis déployez sur le réseau Stellar.",
+    "steps": {
+      "metadata": "Métadonnées",
+      "supply": "Approvisionnement",
+      "admin": "Administrateur",
+      "review": "Révision"
+    },
+    "stepIndicator": "Étape {current}: {name}",
+    "metadata": {
+      "title": "Métadonnées du Token",
+      "description": "Définissez l'identité básica de votre token.",
+      "tokenName": "Nom du Token",
+      "tokenNamePlaceholder": "ex. Mon Stellar Token",
+      "symbol": "Symbole",
+      "symbolPlaceholder": "ex. MYTOK",
+      "decimals": "Décimales",
+      "decimalsPlaceholder": "La valeur par défaut est 7",
+      "descriptionLabel": "Description (optionnel)",
+      "descriptionPlaceholder": "Courte description pour les wallets/explorers",
+      "logoUrl": "URL du Logo (optionnel)",
+      "logoUrlPlaceholder": "https://.../logo.png",
+      "website": "Site Web (optionnel)",
+      "websitePlaceholder": "https://example.com",
+      "twitter": "Twitter (optionnel)",
+      "twitterPlaceholder": "@handle_du_projet ou https://twitter.com/handle",
+      "discord": "Discord (optionnel)",
+      "discordPlaceholder": "Invitation Discord ou handle"
+    },
+    "supply": {
+      "title": "Configuration de l'Approvisionnement",
+      "description": "Définissez l'approvisionnement initial et maximum pour votre token.",
+      "initialSupply": "Approvisionnement Initial",
+      "initialSupplyPlaceholder": "ex. 1000000",
+      "maxSupply": "Approvisionnement Maximum (Optionnel)",
+      "maxSupplyPlaceholder": "Laisser vide pour illimité"
+    },
+    "admin": {
+      "title": "Administration",
+      "description": "Spécifiez l'adresse administrative pour ce token.",
+      "adminAddress": "Adresse de l'Administrateur (Clé Publique Stellar)",
+      "adminAddressPlaceholder": "ex. G...",
+      "warning": "L'administrateur a l'autorité pour minter plus de tokens, modifier les métadonnées du token et gérer d'autres paramètres administratifs. Assurez-vous d'avoir accès à ce compte."
+    },
+    "review": {
+      "title": "Révision et Déploiement",
+      "description": "Vérifiez votre configuration de token avant le déploiement.",
+      "tokenDetails": "Détails du Token",
+      "supplyDetails": "Détails de l'Approvisionnement",
+      "adminDetails": "Détails de l'Administrateur",
+      "readyMessage": "La transaction est prête à être signée"
+    },
+    "buttons": {
+      "deployToken": "Déployer le Token"
+    },
+    "validation": {
+      "nameRequired": "Le nom du token est requis",
+      "nameTooLong": "Nom trop long",
+      "symbolRequired": "Le symbole est requis",
+      "symbolTooLong": "Symbole trop long",
+      "initialSupplyMin": "L'approvisionnement initial doit être au moins 1",
+      "maxSupplyMin": "L'approvisionnement maximum doit être au moins 1",
+      "invalidPublicKey": "Clé publique Stellar invalide",
+      "initialExceedsMax": "L'approvisionnement initial ne peut pas dépasser l'approvisionnement maximum"
+    }
+  },
+  "dashboard": {
+    "title": "Tableau de Bord du Token",
+    "description": "Entrez l'ID de contrat d'un token déployé pour voir les métriques d'approvisionnement, la distribution des holders, et plus.",
+    "searchPlaceholder": "CABC123...XYZ (ID de contrat)",
+    "searchLabel": "ID de Contrat",
+    "viewMyAccount": "Voir Mon Compte",
+    "errors": {
+      "emptyContract": "Veuillez entrer un ID de contrat.",
+      "invalidFormat": "Format d'ID de contrat invalide. Une adresse Stellar de 56 caractères est attendue."
+    }
+  },
+  "settings": {
+    "title": "Paramètres du Réseau",
+    "description": "Configurez des URLs personnalisées Soroban RPC et Horizon. Les modifications sont sauvegardées dans votre navigateur et persistent entre les sessions.",
+    "rpcUrl": "URL Soroban RPC",
+    "horizonUrl": "URL Horizon",
+    "resetToDefaults": "Réinitialiser aux valeurs par défaut",
+    "validation": {
+      "invalidUrl": "Entrez une URL HTTP ou HTTPS valide.",
+      "unreachable": "Impossible d'atteindre cette URL. Veuillez vérifier et réessayer."
+    }
+  },
+  "network": {
+    "testnet": "Testnet",
+    "mainnet": "Mainnet"
+  },
+  "wallet": {
+    "connect": "Connecter le Wallet",
+    "disconnect": "Déconnecter",
+    "connecting": "Connexion..."
+  },
+  "footer": {
+    "builtFor": "Construit pour le",
+    "stellarWave": "Programme Stellar Wave",
+    "license": "Licence MIT"
+  },
+  "accessibility": {
+    "loading": "Chargement",
+    "openMenu": "Ouvrir le menu",
+    "closeMenu": "Fermer le menu",
+    "closeSettings": "Fermer les paramètres"
+  }
+}

--- a/frontend/messages/zh.json
+++ b/frontend/messages/zh.json
@@ -1,0 +1,159 @@
+{
+  "common": {
+    "loading": "加载中...",
+    "error": "错误",
+    "success": "成功",
+    "cancel": "取消",
+    "save": "保存",
+    "back": "返回",
+    "continue": "继续",
+    "view": "查看",
+    "close": "关闭",
+    "submit": "提交",
+    "reset": "重置",
+    "settings": "设置",
+    "check": "检查"
+  },
+  "navigation": {
+    "deploy": "部署",
+    "dashboard": "仪表板",
+    "allowances": "配额",
+    "myAccount": "我的账户",
+    "skipToContent": "跳转到主要内容"
+  },
+  "home": {
+    "badge": "构建于 Stellar Soroban",
+    "title": "部署您的代币",
+    "titleHighlight": "数分钟完成",
+    "description": "SoroPad 是一个开源的部署平台，用于在 Soroban 上部署符合 SEP-41 标准的代币 — 包含归属计划、管理员控制和实时仪表板。无需智能合约代码。",
+    "deployButton": "部署代币",
+    "githubButton": "在 GitHub 上查看",
+    "features": {
+      "deploy": {
+        "icon": "🪙",
+        "title": "一键部署",
+        "description": "填写表单，使用 Freighter 签名，您的 SEP-41 代币即可在 Soroban 上线。"
+      },
+      "vesting": {
+        "icon": "🔒",
+        "title": "归属与控制",
+        "description": "按钱包设置悬崖期 + 线性归属。管理员可铸造、销毁和冻结。"
+      },
+      "dashboard": {
+        "icon": "📊",
+        "title": "实时仪表板",
+        "description": "供应量指标、持有人表、归属进度 — 全部实时更新。"
+      }
+    }
+  },
+  "deploy": {
+    "title": "部署您的",
+    "titleHighlight": "Soroban 代币",
+    "description": "在数分钟内启动生产就绪的 SEP-41 代币。配置您的元数据、供应量和管理权，然后部署到 Stellar 网络。",
+    "steps": {
+      "metadata": "元数据",
+      "supply": "供应量",
+      "admin": "管理员",
+      "review": "审核"
+    },
+    "stepIndicator": "步骤 {current}: {name}",
+    "metadata": {
+      "title": "代币元数据",
+      "description": "定义您的代币基本身份。",
+      "tokenName": "代币名称",
+      "tokenNamePlaceholder": "例如：我的 Stellar 代币",
+      "symbol": "符号",
+      "symbolPlaceholder": "例如：MYTOK",
+      "decimals": "小数位数",
+      "decimalsPlaceholder": "默认值为 7",
+      "descriptionLabel": "描述（可选）",
+      "descriptionPlaceholder": "钱包/浏览器简短描述",
+      "logoUrl": "Logo 网址（可选）",
+      "logoUrlPlaceholder": "https://.../logo.png",
+      "website": "网站（可选）",
+      "websitePlaceholder": "https://example.com",
+      "twitter": "Twitter（可选）",
+      "twitterPlaceholder": "@项目名或 https://twitter.com/用户名",
+      "discord": "Discord（可选）",
+      "discordPlaceholder": "Discord 邀请或用户名"
+    },
+    "supply": {
+      "title": "供应量配置",
+      "description": "设置您的代币初始和最大供应量。",
+      "initialSupply": "初始供应量",
+      "initialSupplyPlaceholder": "例如：1000000",
+      "maxSupply": "最大供应量（可选）",
+      "maxSupplyPlaceholder": "留空以设置为无限"
+    },
+    "admin": {
+      "title": "管理权限",
+      "description": "指定此代币的管理员地址。",
+      "adminAddress": "管理员地址（Stellar 公钥）",
+      "adminAddressPlaceholder": "例如：G...",
+      "warning": "管理员有权铸造更多代币、更改代币元数据和管理其他设置。请确保您有权访问此账户。"
+    },
+    "review": {
+      "title": "审核并部署",
+      "description": "在部署前审核您的代币配置。",
+      "tokenDetails": "代币详情",
+      "supplyDetails": "供应量详情",
+      "adminDetails": "管理员详情",
+      "readyMessage": "交易已准备好签名"
+    },
+    "buttons": {
+      "deployToken": "部署代币"
+    },
+    "validation": {
+      "nameRequired": "代币名称为必填项",
+      "nameTooLong": "名称过长",
+      "symbolRequired": "符号为必填项",
+      "symbolTooLong": "符号过长",
+      "initialSupplyMin": "初始供应量至少为 1",
+      "maxSupplyMin": "最大供应量至少为 1",
+      "invalidPublicKey": "无效的 Stellar 公钥",
+      "initialExceedsMax": "初始供应量不能超过最大供应量"
+    }
+  },
+  "dashboard": {
+    "title": "代币仪表板",
+    "description": "输入已部署代币的合约 ID 以查看供应量指标、持有人分布等。",
+    "searchPlaceholder": "CABC123...XYZ（合约 ID）",
+    "searchLabel": "合约 ID",
+    "viewMyAccount": "查看我的账户",
+    "errors": {
+      "emptyContract": "请输入合约 ID。",
+      "invalidFormat": "无效的合约 ID 格式。应为 56 位 Stellar 地址。"
+    }
+  },
+  "settings": {
+    "title": "网络设置",
+    "description": "配置自定义 Soroban RPC 和 Horizon 网址。更改将保存到您的浏览器并在会话间保留。",
+    "rpcUrl": "Soroban RPC 网址",
+    "horizonUrl": "Horizon 网址",
+    "resetToDefaults": "重置为默认值",
+    "validation": {
+      "invalidUrl": "输入有效的 HTTP 或 HTTPS 网址。",
+      "unreachable": "无法访问此网址。请检查后重试。"
+    }
+  },
+  "network": {
+    "testnet": "测试网",
+    "mainnet": "主网"
+  },
+  "wallet": {
+    "connect": "连接钱包",
+    "disconnect": "断开连接",
+    "connecting": "连接中..."
+  },
+  "footer": {
+    "builtFor": "为",
+    "stellarWave": "Stellar Wave 计划构建",
+    "license": "MIT 许可证"
+  },
+  "accessibility": {
+    "loading": "加载中",
+    "openMenu": "打开菜单",
+    "closeMenu": "关闭菜单",
+    "closeSettings": "关闭设置"
+  }
+}


### PR DESCRIPTION
Expand internationalization to support 3 additional locales beyond English. The language selector now offers 4 languages with persistent user preference.

Files Changed:
- lib/i18n.ts: Expand locales array from ["en"] to ["en", "es", "fr", "zh"]
- app/layout.tsx: Add LocaleProvider wrapper to enable client-side locale switching
- app/providers/I18nProvider.tsx: Refactor to use LocaleProvider context
- app/components/LanguageSwitcher.tsx: Update SUPPORTED_LOCALES and integrate with useLocale

Files Added:
- messages/es.json: Spanish translations (159 keys)
- messages/fr.json: French translations (159 keys)
- messages/zh.json: Chinese Simplified translations (159 keys)
- app/providers/LocaleProvider.tsx: New React context for locale state management

Translation Coverage:
- common, navigation, deploy (full form), network, wallet

**Closes #126**
