### PR TITLE
Fix/issues 145 151

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 target/
 frontend/.next
 frontend/node_modules
+issue.md
+pr.md

--- a/contracts/token/src/lib.rs
+++ b/contracts/token/src/lib.rs
@@ -357,8 +357,10 @@ impl TokenContract {
     }
 
     /// Approve `spender` to spend up to `amount` on behalf of `from`.
-    /// The allowance will be extended with TTL up to the specified expiration_ledger.
-    /// If expiration_ledger is 0, the allowance will use a default TTL extension.
+    ///
+    /// `expiration_ledger` must be strictly greater than the current ledger
+    /// sequence. The allowance TTL is derived from this value, so callers
+    /// must supply a valid future ledger (SEP-41 requirement).
     pub fn approve(
         env: Env,
         from: Address,
@@ -369,19 +371,18 @@ impl TokenContract {
         from.require_auth();
         assert!(amount >= 0, "amount must be non-negative");
 
+        let current_ledger = env.ledger().sequence();
+        assert!(
+            expiration_ledger > current_ledger,
+            "expiration_ledger must be in the future"
+        );
+
         let key = DataKey::Allowance(from.clone(), spender.clone());
         env.storage().persistent().set(&key, &amount);
 
-        // Extend TTL for the allowance key
-        // If expiration_ledger is 0 or in the past, use default TTL (52 weeks)
-        let current_ledger = env.ledger().sequence();
-        let ttl_ledgers = if expiration_ledger > current_ledger {
-            expiration_ledger - current_ledger
-        } else {
-            // Default TTL: 52 weeks in ledgers (assuming 5-second ledgers)
-            52 * 7 * 24 * 60 / 5
-        };
-
+        // Use the caller-supplied expiration to set the allowance TTL exactly
+        // as the SEP-41 standard requires — no silent fallback.
+        let ttl_ledgers = expiration_ledger - current_ledger;
         env.storage()
             .persistent()
             .extend_ttl(&key, ttl_ledgers, ttl_ledgers);
@@ -930,7 +931,7 @@ mod test {
         let (env, client, admin, user) = setup();
         let spender = Address::generate(&env);
 
-        client.approve(&admin, &spender, &100_0000000i128, &0u32);
+        client.approve(&admin, &spender, &100_0000000i128, &1000u32);
         assert_eq!(client.allowance(&admin, &spender), 100_0000000i128);
 
         client.transfer_from(&spender, &admin, &user, &60_0000000i128);
@@ -948,7 +949,7 @@ mod test {
         let (env, client, admin, user) = setup();
         let spender = Address::generate(&env);
 
-        client.approve(&admin, &spender, &10i128, &0u32);
+        client.approve(&admin, &spender, &10i128, &1000u32);
         client.transfer_from(&spender, &admin, &user, &11i128);
     }
 
@@ -1015,7 +1016,7 @@ mod test {
         let spender = Address::generate(&env);
         // Give user some tokens and approve spender.
         client.transfer(&admin, &user, &1000i128);
-        client.approve(&user, &spender, &1000i128, &0u32);
+        client.approve(&user, &spender, &1000i128, &1000u32);
         // Freeze user, then attempt transfer_from.
         client.freeze_account(&user);
         client.transfer_from(&spender, &user, &admin, &500i128);
@@ -1187,7 +1188,7 @@ mod test {
     fn test_paused_transfer_from_blocked() {
         let (env, client, admin, user) = setup();
         let spender = Address::generate(&env);
-        client.approve(&admin, &spender, &1000i128, &0u32);
+        client.approve(&admin, &spender, &1000i128, &1000u32);
         client.pause();
         client.transfer_from(&spender, &admin, &user, &500i128);
     }
@@ -1517,5 +1518,25 @@ mod test {
         client.authorize_holder(&user);
         client.mint(&user, &1000i128);
         assert_eq!(client.balance(&user), 1000i128);
+    }
+
+    // ── approve expiration tests ────────────────────────────────────────
+
+    #[test]
+    #[should_panic(expected = "expiration_ledger must be in the future")]
+    fn test_approve_expired_ledger_panics() {
+        let (env, client, admin, _) = setup();
+        let spender = Address::generate(&env);
+        // Ledger sequence is 0 by default; expiration_ledger = 0 is NOT in the future.
+        client.approve(&admin, &spender, &100i128, &0u32);
+    }
+
+    #[test]
+    fn test_approve_respects_expiration_ledger() {
+        let (env, client, admin, _) = setup();
+        let spender = Address::generate(&env);
+        // Supply a valid future expiration; the allowance should be stored correctly.
+        client.approve(&admin, &spender, &500i128, &100u32);
+        assert_eq!(client.allowance(&admin, &spender), 500i128);
     }
 }

--- a/contracts/vesting/src/lib.rs
+++ b/contracts/vesting/src/lib.rs
@@ -245,6 +245,45 @@ impl VestingContract {
             .publish((symbol_short!("revoke"), recipient), (releasable, unvested));
     }
 
+    /// Admin-only: extend the cliff ledger of an existing (non-revoked) schedule.
+    ///
+    /// Rules enforced:
+    /// - `new_cliff` must be strictly greater than the current `cliff_ledger`
+    ///   (extension only — reduction is never allowed).
+    /// - The current ledger must still be before the cliff (once the cliff has
+    ///   already passed there is nothing left to delay).
+    /// - `new_cliff` must remain strictly less than `end_ledger`.
+    pub fn extend_cliff(env: Env, recipient: Address, new_cliff: u32) {
+        Self::_require_admin(&env);
+
+        let key = DataKey::Schedule(recipient.clone());
+        let mut schedule: VestingSchedule = env
+            .storage()
+            .persistent()
+            .get(&key)
+            .expect("no schedule found");
+
+        assert!(!schedule.revoked, "schedule has been revoked");
+        assert!(
+            env.ledger().sequence() < schedule.cliff_ledger,
+            "cliff has already passed"
+        );
+        assert!(
+            new_cliff > schedule.cliff_ledger,
+            "new_cliff must be later than current cliff"
+        );
+        assert!(
+            new_cliff < schedule.end_ledger,
+            "new_cliff must be before end_ledger"
+        );
+
+        schedule.cliff_ledger = new_cliff;
+        env.storage().persistent().set(&key, &schedule);
+
+        env.events()
+            .publish((symbol_short!("clf_ext"), recipient), new_cliff);
+    }
+
     // ── Read-only queries ───────────────────────────────────────────────
 
     /// Total amount vested so far (may or may not have been released).
@@ -546,6 +585,77 @@ mod test {
         let token = Address::generate(&env);
         client.initialize(&admin, &token);
         client.revoke(&recipient);
+    }
+
+    // ── extend_cliff tests ─────────────────────────────────────────────
+
+    #[test]
+    fn test_extend_cliff_success() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let contract_id = env.register_contract(None, VestingContract);
+        let client = VestingContractClient::new(&env, &contract_id);
+        let (_, recipient) = setup_schedule(&env, &client);
+
+        // Cliff is at 100; extend it to 150 while current ledger is still 0
+        client.extend_cliff(&recipient, &150u32);
+
+        let schedule = client.get_schedule(&recipient);
+        assert_eq!(schedule.cliff_ledger, 150);
+        assert_eq!(schedule.end_ledger, 200); // unchanged
+    }
+
+    #[test]
+    #[should_panic(expected = "new_cliff must be later than current cliff")]
+    fn test_extend_cliff_cannot_reduce() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let contract_id = env.register_contract(None, VestingContract);
+        let client = VestingContractClient::new(&env, &contract_id);
+        let (_, recipient) = setup_schedule(&env, &client);
+
+        // cliff is 100; trying to set it to 50 must panic
+        client.extend_cliff(&recipient, &50u32);
+    }
+
+    #[test]
+    #[should_panic(expected = "cliff has already passed")]
+    fn test_extend_cliff_after_cliff_passed() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let contract_id = env.register_contract(None, VestingContract);
+        let client = VestingContractClient::new(&env, &contract_id);
+        let (_, recipient) = setup_schedule(&env, &client);
+
+        // Jump past the cliff
+        env.ledger().set_sequence_number(120);
+        client.extend_cliff(&recipient, &150u32);
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_extend_cliff_non_admin_panics() {
+        let env = Env::default();
+        // Do NOT mock all auths — only mock nothing so admin auth fails
+        let contract_id = env.register_contract(None, VestingContract);
+        let client = VestingContractClient::new(&env, &contract_id);
+        let admin = Address::generate(&env);
+        let token = env.register_stellar_asset_contract(admin.clone());
+        let asset_client = soroban_sdk::token::StellarAssetClient::new(&env, &token);
+
+        // Use mock_all_auths only for setup
+        env.mock_all_auths();
+        client.initialize(&admin, &token);
+        asset_client.mint(&admin, &1_000_000i128);
+        let recipient = Address::generate(&env);
+        client.create_schedule(&recipient, &1_000i128, &100u32, &200u32);
+
+        // Clear auths so the next call fails
+        env.set_auths(&[]);
+        client.extend_cliff(&recipient, &150u32);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Implements `extend_cliff` capability for unvested vesting schedules and fixes the ignored `_expiration_ledger` argument in `approve`.

**Closes #151**
**Closes #145**

## Changes

- [x] Add `extend_cliff(env, recipient, new_cliff)` to `VestingContract` — admin-only, extension-only, blocked after cliff passes
- [x] Add 4 tests for `extend_cliff` (success, reduction rejected, post-cliff rejected, non-admin panics)
- [x] Fix `approve` in token contract to validate `expiration_ledger > current_ledger` and enforce it as the allowance TTL
- [x] Update 4 existing `approve` tests to pass a valid future expiration ledger
- [x] Add 2 new `approve` tests (`test_approve_expired_ledger_panics`, `test_approve_respects_expiration_ledger`)

## Type

- [x] 🐛 Bug fix
- [x] ✨ New feature
- [ ] ♻️ Refactor
- [ ] 📝 Documentation
- [x] 🧪 Tests

## Checklist

- [x] My code follows the project's style guidelines
- [x] I've added/updated tests that cover my changes
- [x] All existing tests pass (`cargo test` / `npm test`)
- [x] I've updated documentation if needed
- [ ] I've tested on Stellar Testnet (if applicable)

## Screenshots / Recordings

<!-- N/A — contract-only changes, no UI -->
