### PR TITLE
feat: Custom Notification Center & Toast History (#160)

### DIFF
--- a/frontend/app/components/Navbar.tsx
+++ b/frontend/app/components/Navbar.tsx
@@ -5,6 +5,7 @@ import { useNetwork } from "../providers/NetworkProvider";
 import { WalletButton } from "./WalletButton";
 import { SettingsModal } from "./SettingsModal";
 import { LanguageSwitcher } from "./LanguageSwitcher";
+import { NotificationCenter } from "./NotificationCenter";
 import { Globe, ChevronDown, Menu, X } from "lucide-react";
 import { useState } from "react";
 
@@ -56,6 +57,9 @@ export function Navbar() {
         <div className="flex items-center gap-3">
           <LanguageSwitcher />
           <NetworkSwitcher />
+
+          {/* Notification Center — transaction history */}
+          <NotificationCenter />
 
           {/* Custom RPC / Horizon settings */}
           <SettingsModal />

--- a/frontend/app/components/NotificationCenter.tsx
+++ b/frontend/app/components/NotificationCenter.tsx
@@ -1,0 +1,200 @@
+"use client";
+
+import { useState, useRef, useEffect } from "react";
+import {
+  Bell,
+  X,
+  Trash2,
+  ExternalLink,
+  AlertTriangle,
+  CheckCircle2,
+  Info,
+  XCircle,
+} from "lucide-react";
+import {
+  useNotifications,
+  type Notification,
+  type NotificationVariant,
+} from "../providers/NotificationProvider";
+import { useNetwork } from "../providers/NetworkProvider";
+
+const variantStyles: Record<
+  NotificationVariant,
+  { icon: React.ComponentType<{ className?: string }>; iconColor: string }
+> = {
+  info: { icon: Info, iconColor: "text-blue-400" },
+  success: { icon: CheckCircle2, iconColor: "text-emerald-400" },
+  warning: { icon: AlertTriangle, iconColor: "text-yellow-400" },
+  error: { icon: XCircle, iconColor: "text-red-400" },
+};
+
+function formatTimestamp(timestamp: number): string {
+  const now = Date.now();
+  const diff = now - timestamp;
+
+  if (diff < 60_000) return "Just now";
+  if (diff < 3_600_000) return `${Math.floor(diff / 60_000)}m ago`;
+  if (diff < 86_400_000) return `${Math.floor(diff / 3_600_000)}h ago`;
+  return new Date(timestamp).toLocaleDateString();
+}
+
+function NotificationItem({
+  notification,
+  onRemove,
+  explorerUrl,
+}: {
+  notification: Notification;
+  onRemove: (id: string) => void;
+  explorerUrl: string;
+}) {
+  const styles = variantStyles[notification.variant];
+  const Icon = styles.icon;
+
+  return (
+    <div className="group flex items-start gap-3 rounded-lg p-3 transition-colors hover:bg-white/5">
+      <Icon className={`h-4 w-4 shrink-0 mt-0.5 ${styles.iconColor}`} />
+      <div className="min-w-0 flex-1">
+        <div className="flex items-start justify-between gap-2">
+          <p className="text-sm font-medium text-white truncate">
+            {notification.title}
+          </p>
+          <span className="text-[10px] text-gray-500 whitespace-nowrap">
+            {formatTimestamp(notification.timestamp)}
+          </span>
+        </div>
+        {notification.message && (
+          <p className="mt-0.5 text-xs text-gray-400 line-clamp-2">
+            {notification.message}
+          </p>
+        )}
+        {notification.txHash && (
+          <a
+            href={`${explorerUrl}/tx/${notification.txHash}`}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="mt-1.5 inline-flex items-center gap-1 text-[10px] text-stellar-400 hover:text-stellar-300 transition-colors"
+          >
+            <span className="font-mono">
+              {notification.txHash.slice(0, 8)}...{notification.txHash.slice(-8)}
+            </span>
+            <ExternalLink className="h-2.5 w-2.5" />
+          </a>
+        )}
+      </div>
+      <button
+        onClick={() => onRemove(notification.id)}
+        className="opacity-0 group-hover:opacity-100 rounded p-1 text-gray-500 transition-all hover:bg-white/10 hover:text-white"
+        aria-label="Remove notification"
+      >
+        <X className="h-3 w-3" />
+      </button>
+    </div>
+  );
+}
+
+export function NotificationCenter() {
+  const { notifications, unreadCount, markAllRead, clear, remove } =
+    useNotifications();
+  const { networkConfig } = useNetwork();
+  const [isOpen, setIsOpen] = useState(false);
+  const dropdownRef = useRef<HTMLDivElement>(null);
+
+  const explorerUrl =
+    networkConfig.network === "mainnet"
+      ? "https://stellar.expert/explorer/public"
+      : "https://stellar.expert/explorer/testnet";
+
+  // Close dropdown when clicking outside
+  useEffect(() => {
+    function handleClickOutside(event: MouseEvent) {
+      if (
+        dropdownRef.current &&
+        !dropdownRef.current.contains(event.target as Node)
+      ) {
+        setIsOpen(false);
+      }
+    }
+
+    if (isOpen) {
+      document.addEventListener("mousedown", handleClickOutside);
+      return () =>
+        document.removeEventListener("mousedown", handleClickOutside);
+    }
+  }, [isOpen]);
+
+  // Mark as read when opening
+  const handleToggle = () => {
+    if (!isOpen && unreadCount > 0) {
+      markAllRead();
+    }
+    setIsOpen(!isOpen);
+  };
+
+  return (
+    <div className="relative" ref={dropdownRef}>
+      <button
+        onClick={handleToggle}
+        className="relative flex items-center justify-center rounded-lg border border-white/10 bg-white/5 p-1.5 text-gray-400 transition-colors hover:bg-white/10 hover:text-white"
+        aria-label={`Notifications${unreadCount > 0 ? ` (${unreadCount} unread)` : ""}`}
+      >
+        <Bell className="h-4 w-4" />
+        {unreadCount > 0 && (
+          <span className="absolute -right-1 -top-1 flex h-4 min-w-4 items-center justify-center rounded-full bg-red-500 px-1 text-[10px] font-bold text-white">
+            {unreadCount > 9 ? "9+" : unreadCount}
+          </span>
+        )}
+      </button>
+
+      {isOpen && (
+        <div className="absolute right-0 mt-2 w-80 origin-top-right rounded-xl border border-white/10 bg-void-800 shadow-2xl z-50 animate-in fade-in zoom-in-95 duration-100">
+          {/* Header */}
+          <div className="flex items-center justify-between border-b border-white/5 px-4 py-3">
+            <h3 className="text-sm font-semibold text-white">Notifications</h3>
+            {notifications.length > 0 && (
+              <button
+                onClick={clear}
+                className="flex items-center gap-1 text-[10px] text-gray-500 transition-colors hover:text-red-400"
+              >
+                <Trash2 className="h-3 w-3" />
+                Clear all
+              </button>
+            )}
+          </div>
+
+          {/* Notification list */}
+          <div className="max-h-80 overflow-y-auto">
+            {notifications.length === 0 ? (
+              <div className="flex flex-col items-center justify-center py-8 text-gray-500">
+                <Bell className="h-8 w-8 mb-2 opacity-50" />
+                <p className="text-xs">No notifications yet</p>
+                <p className="text-[10px] mt-1 text-gray-600">
+                  Transaction history will appear here
+                </p>
+              </div>
+            ) : (
+              <div className="divide-y divide-white/5">
+                {notifications.map((notification) => (
+                  <NotificationItem
+                    key={notification.id}
+                    notification={notification}
+                    onRemove={remove}
+                    explorerUrl={explorerUrl}
+                  />
+                ))}
+              </div>
+            )}
+          </div>
+
+          {/* Footer */}
+          {notifications.length > 0 && (
+            <div className="border-t border-white/5 px-4 py-2">
+              <p className="text-[10px] text-gray-600 text-center">
+                Showing last {notifications.length} of 15 max
+              </p>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -8,6 +8,7 @@ import { AccessibilityProvider } from "./providers/AccessibilityProvider";
 import { LocaleProvider } from "./providers/LocaleProvider";
 import { I18nProvider } from "./providers/I18nProvider";
 import { ToastProvider } from "./providers/ToastProvider";
+import { NotificationProvider } from "./providers/NotificationProvider";
 import { ErrorBoundary } from "./components/ErrorBoundary";
 import { Navbar } from "./components/Navbar";
 import { MainnetWarning } from "./components/MainnetWarning";
@@ -50,40 +51,42 @@ export default function RootLayout({
           Skip to main content
         </a>
         <LocaleProvider>
+          <NotificationProvider>
             <ToastProvider>
-          <I18nProvider>
-            <NetworkProvider>
-              <SettingsProvider>
-                <WalletProvider>
-                  <AccessibilityProvider>
-                    <Navbar />
-                    <MainnetWarning />
-                    <main id="main-content" className="pt-16" role="main">
-                      <ErrorBoundary>{children}</ErrorBoundary>
-                    </main>
-                    <footer
-                      role="contentinfo"
-                      className="border-t border-white/5 py-8 text-center text-sm text-gray-500"
-                    >
-                      <p>
-                        Built for the{" "}
-                        <a
-                          href="https://www.drips.network/wave"
-                          className="text-stellar-400 hover:underline"
-                          target="_blank"
-                          rel="noopener noreferrer"
+              <I18nProvider>
+                <NetworkProvider>
+                  <SettingsProvider>
+                    <WalletProvider>
+                      <AccessibilityProvider>
+                        <Navbar />
+                        <MainnetWarning />
+                        <main id="main-content" className="pt-16" role="main">
+                          <ErrorBoundary>{children}</ErrorBoundary>
+                        </main>
+                        <footer
+                          role="contentinfo"
+                          className="border-t border-white/5 py-8 text-center text-sm text-gray-500"
                         >
-                          Stellar Wave Program
-                        </a>{" "}
-                        · MIT License
-                      </p>
-                    </footer>
-                  </AccessibilityProvider>
-                </WalletProvider>
-              </SettingsProvider>
-            </NetworkProvider>
-          </I18nProvider>
-        </ToastProvider>
+                          <p>
+                            Built for the{" "}
+                            <a
+                              href="https://www.drips.network/wave"
+                              className="text-stellar-400 hover:underline"
+                              target="_blank"
+                              rel="noopener noreferrer"
+                            >
+                              Stellar Wave Program
+                            </a>{" "}
+                            · MIT License
+                          </p>
+                        </footer>
+                      </AccessibilityProvider>
+                    </WalletProvider>
+                  </SettingsProvider>
+                </NetworkProvider>
+              </I18nProvider>
+            </ToastProvider>
+          </NotificationProvider>
         </LocaleProvider>
       </body>
     </html>

--- a/frontend/app/providers/NotificationProvider.tsx
+++ b/frontend/app/providers/NotificationProvider.tsx
@@ -1,0 +1,158 @@
+"use client";
+
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+  type ReactNode,
+} from "react";
+
+export type NotificationVariant = "info" | "success" | "warning" | "error";
+
+export interface Notification {
+  id: string;
+  title: string;
+  message?: string;
+  variant: NotificationVariant;
+  timestamp: number;
+  txHash?: string;
+}
+
+export interface NotificationInput {
+  title: string;
+  message?: string;
+  variant?: NotificationVariant;
+  txHash?: string;
+}
+
+interface NotificationContextValue {
+  notifications: Notification[];
+  unreadCount: number;
+  add: (notification: NotificationInput) => string;
+  markAllRead: () => void;
+  clear: () => void;
+  remove: (id: string) => void;
+}
+
+const NotificationContext = createContext<NotificationContextValue | undefined>(
+  undefined,
+);
+
+const MAX_NOTIFICATIONS = 15;
+const STORAGE_KEY = "soropad_notifications";
+
+export function NotificationProvider({ children }: { children: ReactNode }) {
+  const [notifications, setNotifications] = useState<Notification[]>([]);
+  const [unreadCount, setUnreadCount] = useState(0);
+  const [mounted, setMounted] = useState(false);
+
+  // Load from localStorage on mount
+  useEffect(() => {
+    setMounted(true);
+    if (typeof window === "undefined") return;
+    try {
+      const stored = localStorage.getItem(STORAGE_KEY);
+      if (stored) {
+        const parsed = JSON.parse(stored) as {
+          notifications: Notification[];
+          unreadCount: number;
+        };
+        setNotifications(parsed.notifications ?? []);
+        setUnreadCount(parsed.unreadCount ?? 0);
+      }
+    } catch {
+      // Ignore parse errors
+    }
+  }, []);
+
+  // Persist to localStorage on change
+  useEffect(() => {
+    if (!mounted || typeof window === "undefined") return;
+    try {
+      localStorage.setItem(
+        STORAGE_KEY,
+        JSON.stringify({ notifications, unreadCount }),
+      );
+    } catch {
+      // Ignore storage errors
+    }
+  }, [notifications, unreadCount, mounted]);
+
+  const add = useCallback((input: NotificationInput): string => {
+    const id =
+      typeof crypto !== "undefined" && "randomUUID" in crypto
+        ? crypto.randomUUID()
+        : `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+
+    const notification: Notification = {
+      id,
+      title: input.title,
+      message: input.message,
+      variant: input.variant ?? "info",
+      timestamp: Date.now(),
+      txHash: input.txHash,
+    };
+
+    setNotifications((prev) => {
+      const next = [notification, ...prev];
+      return next.length > MAX_NOTIFICATIONS
+        ? next.slice(0, MAX_NOTIFICATIONS)
+        : next;
+    });
+    setUnreadCount((prev) => prev + 1);
+
+    return id;
+  }, []);
+
+  const markAllRead = useCallback(() => {
+    setUnreadCount(0);
+  }, []);
+
+  const clear = useCallback(() => {
+    setNotifications([]);
+    setUnreadCount(0);
+  }, []);
+
+  const remove = useCallback((id: string) => {
+    setNotifications((prev) => prev.filter((n) => n.id !== id));
+  }, []);
+
+  // Bridge: allow non-React modules to push notifications
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    interface NotificationBridge {
+      add: (n: NotificationInput) => string;
+    }
+    const w = window as unknown as { __soropadNotifications?: NotificationBridge };
+    w.__soropadNotifications = { add };
+    return () => {
+      if (w.__soropadNotifications) {
+        delete w.__soropadNotifications;
+      }
+    };
+  }, [add]);
+
+  const value = useMemo<NotificationContextValue>(
+    () => ({ notifications, unreadCount, add, markAllRead, clear, remove }),
+    [notifications, unreadCount, add, markAllRead, clear, remove],
+  );
+
+  return (
+    <NotificationContext.Provider value={value}>
+      {children}
+    </NotificationContext.Provider>
+  );
+}
+
+export function useNotifications(): NotificationContextValue {
+  const ctx = useContext(NotificationContext);
+  if (!ctx) {
+    throw new Error(
+      "useNotifications must be used within a <NotificationProvider>",
+    );
+  }
+  return ctx;
+}

--- a/frontend/app/providers/ToastProvider.tsx
+++ b/frontend/app/providers/ToastProvider.tsx
@@ -27,6 +27,7 @@ export interface ToastInput {
   message?: string;
   variant?: ToastVariant;
   duration?: number;
+  txHash?: string;
 }
 
 interface ToastContextValue {
@@ -71,8 +72,32 @@ export function ToastProvider({ children }: { children: ReactNode }) {
 
       setToasts((prev) => {
         const next = [...prev, toast];
-        return next.length > MAX_TOASTS ? next.slice(next.length - MAX_TOASTS) : next;
+        return next.length > MAX_TOASTS
+          ? next.slice(next.length - MAX_TOASTS)
+          : next;
       });
+
+      // Push to notification history for persistence
+      if (typeof window !== "undefined") {
+        const notifBridge = (
+          window as unknown as {
+            __soropadNotifications?: {
+              add: (n: {
+                title: string;
+                message?: string;
+                variant?: ToastVariant;
+                txHash?: string;
+              }) => string;
+            };
+          }
+        ).__soropadNotifications;
+        notifBridge?.add({
+          title: input.title,
+          message: input.message,
+          variant: input.variant,
+          txHash: input.txHash,
+        });
+      }
 
       if (toast.duration > 0) {
         const timer = setTimeout(() => dismiss(id), toast.duration);
@@ -159,9 +184,17 @@ function ToastViewport({
 
 const variantStyles: Record<
   ToastVariant,
-  { border: string; icon: React.ComponentType<{ className?: string }>; iconColor: string }
+  {
+    border: string;
+    icon: React.ComponentType<{ className?: string }>;
+    iconColor: string;
+  }
 > = {
-  info: { border: "border-blue-500/30", icon: Info, iconColor: "text-blue-400" },
+  info: {
+    border: "border-blue-500/30",
+    icon: Info,
+    iconColor: "text-blue-400",
+  },
   success: {
     border: "border-emerald-500/30",
     icon: CheckCircle2,
@@ -172,7 +205,11 @@ const variantStyles: Record<
     icon: AlertTriangle,
     iconColor: "text-yellow-400",
   },
-  error: { border: "border-red-500/30", icon: XCircle, iconColor: "text-red-400" },
+  error: {
+    border: "border-red-500/30",
+    icon: XCircle,
+    iconColor: "text-red-400",
+  },
 };
 
 function ToastItem({

--- a/frontend/app/providers/__tests__/NotificationProvider.test.tsx
+++ b/frontend/app/providers/__tests__/NotificationProvider.test.tsx
@@ -1,0 +1,164 @@
+import { act, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import {
+  NotificationProvider,
+  useNotifications,
+  type NotificationVariant,
+} from "../NotificationProvider";
+
+const STORAGE_KEY = "soropad_notifications";
+
+function Trigger({ variant = "info" }: { variant?: NotificationVariant }) {
+  const { add, notifications, unreadCount, markAllRead, clear } =
+    useNotifications();
+  return (
+    <div>
+      <button
+        onClick={() =>
+          add({
+            title: "Test Notification",
+            message: "Test message",
+            variant,
+            txHash: "abc123def456",
+          })
+        }
+      >
+        Add notification
+      </button>
+      <button onClick={markAllRead}>Mark all read</button>
+      <button onClick={clear}>Clear all</button>
+      <span data-testid="count">{notifications.length}</span>
+      <span data-testid="unread">{unreadCount}</span>
+    </div>
+  );
+}
+
+describe("NotificationProvider", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    delete (window as unknown as { __soropadNotifications?: unknown })
+      .__soropadNotifications;
+  });
+
+  it("adds notifications and tracks unread count", async () => {
+    const user = userEvent.setup();
+    render(
+      <NotificationProvider>
+        <Trigger />
+      </NotificationProvider>,
+    );
+
+    expect(screen.getByTestId("count")).toHaveTextContent("0");
+    expect(screen.getByTestId("unread")).toHaveTextContent("0");
+
+    await user.click(screen.getByRole("button", { name: /add notification/i }));
+
+    expect(screen.getByTestId("count")).toHaveTextContent("1");
+    expect(screen.getByTestId("unread")).toHaveTextContent("1");
+  });
+
+  it("marks all notifications as read", async () => {
+    const user = userEvent.setup();
+    render(
+      <NotificationProvider>
+        <Trigger />
+      </NotificationProvider>,
+    );
+
+    await user.click(screen.getByRole("button", { name: /add notification/i }));
+    await user.click(screen.getByRole("button", { name: /add notification/i }));
+
+    expect(screen.getByTestId("unread")).toHaveTextContent("2");
+
+    await user.click(screen.getByRole("button", { name: /mark all read/i }));
+
+    expect(screen.getByTestId("unread")).toHaveTextContent("0");
+    expect(screen.getByTestId("count")).toHaveTextContent("2");
+  });
+
+  it("clears all notifications", async () => {
+    const user = userEvent.setup();
+    render(
+      <NotificationProvider>
+        <Trigger />
+      </NotificationProvider>,
+    );
+
+    await user.click(screen.getByRole("button", { name: /add notification/i }));
+    await user.click(screen.getByRole("button", { name: /add notification/i }));
+
+    expect(screen.getByTestId("count")).toHaveTextContent("2");
+
+    await user.click(screen.getByRole("button", { name: /clear all/i }));
+
+    expect(screen.getByTestId("count")).toHaveTextContent("0");
+    expect(screen.getByTestId("unread")).toHaveTextContent("0");
+  });
+
+  it("limits notifications to 15 max", async () => {
+    const user = userEvent.setup();
+    render(
+      <NotificationProvider>
+        <Trigger />
+      </NotificationProvider>,
+    );
+
+    for (let i = 0; i < 20; i++) {
+      await user.click(
+        screen.getByRole("button", { name: /add notification/i }),
+      );
+    }
+
+    expect(screen.getByTestId("count")).toHaveTextContent("15");
+  });
+
+  it("persists notifications to localStorage", async () => {
+    const user = userEvent.setup();
+    const { unmount } = render(
+      <NotificationProvider>
+        <Trigger />
+      </NotificationProvider>,
+    );
+
+    await user.click(screen.getByRole("button", { name: /add notification/i }));
+
+    // Wait for localStorage to be updated
+    await new Promise((r) => setTimeout(r, 50));
+
+    const stored = localStorage.getItem(STORAGE_KEY);
+    expect(stored).not.toBeNull();
+
+    const parsed = JSON.parse(stored!);
+    expect(parsed.notifications).toHaveLength(1);
+    expect(parsed.notifications[0].title).toBe("Test Notification");
+    expect(parsed.notifications[0].txHash).toBe("abc123def456");
+
+    unmount();
+  });
+
+  it("installs a window bridge for non-React modules", () => {
+    render(
+      <NotificationProvider>
+        <span>child</span>
+      </NotificationProvider>,
+    );
+
+    const bridge = (
+      window as unknown as {
+        __soropadNotifications?: {
+          add: (n: { title: string }) => string;
+        };
+      }
+    ).__soropadNotifications;
+
+    expect(bridge).toBeDefined();
+
+    act(() => {
+      bridge!.add({ title: "From bridge" });
+    });
+
+    // Bridge adds to internal state, which persists to localStorage
+    const stored = localStorage.getItem(STORAGE_KEY);
+    expect(stored).not.toBeNull();
+  });
+});

--- a/frontend/lib/soroban.ts
+++ b/frontend/lib/soroban.ts
@@ -74,6 +74,7 @@ interface ToastBridge {
     message?: string;
     variant?: "info" | "success" | "warning" | "error";
     duration?: number;
+    txHash?: string;
   }) => string;
 }
 
@@ -183,7 +184,8 @@ function classifyByStatus(status: number, raw?: string): RpcErrorInfo {
       status,
       title: `RPC server error (${status})`,
       message:
-        raw ?? "The Soroban RPC server returned an error. Please retry shortly.",
+        raw ??
+        "The Soroban RPC server returned an error. Please retry shortly.",
     };
   }
   return {
@@ -201,6 +203,8 @@ export interface WrapRpcOptions {
   silent?: boolean;
   /** Override the toast title. */
   toastTitle?: string;
+  /** Transaction hash for linking in notification history. */
+  txHash?: string;
 }
 
 /**
@@ -227,6 +231,7 @@ export async function wrapRpcCall<T>(
           info.kind === "timeout" || info.kind === "network"
             ? "warning"
             : "error",
+        txHash: options.txHash,
       });
     }
 


### PR DESCRIPTION
## Problem

Toast notifications for failed Soroban transactions vanish after a few seconds, leaving users unable to retrieve error logs or transaction hashes without digging through browser DevTools.

## Solution

- Added a **bell icon** in the Navbar representing a Notification Center
- Stores the **last 15 transaction attempts and errors** in local state (persisted to localStorage)
- Each notification displays:
  - Title, message, and variant (info/success/warning/error)
  - Timestamp with relative formatting ("Just now", "5m ago", etc.)
  - Clickable transaction hash linking to Stellar Expert explorer
- Unread badge shows count of new notifications
- "Clear all" functionality to reset history

## Changes

| File | Action |
|------|--------|
| [frontend/app/providers/NotificationProvider.tsx](cci:7://file:///home/dsotec/Documents/launchpad/frontend/app/providers/NotificationProvider.tsx:0:0-0:0) | Created - Context provider with localStorage persistence |
| [frontend/app/components/NotificationCenter.tsx](cci:7://file:///home/dsotec/Documents/launchpad/frontend/app/components/NotificationCenter.tsx:0:0-0:0) | Created - Bell icon dropdown component |
| [frontend/app/providers/ToastProvider.tsx](cci:7://file:///home/dsotec/Documents/launchpad/frontend/app/providers/ToastProvider.tsx:0:0-0:0) | Modified - Bridge toasts to notification history |
| [frontend/lib/soroban.ts](cci:7://file:///home/dsotec/Documents/launchpad/frontend/lib/soroban.ts:0:0-0:0) | Modified - Added txHash support to wrapRpcCall |
| [frontend/app/components/Navbar.tsx](cci:7://file:///home/dsotec/Documents/launchpad/frontend/app/components/Navbar.tsx:0:0-0:0) | Modified - Added NotificationCenter |
| [frontend/app/layout.tsx](cci:7://file:///home/dsotec/Documents/launchpad/frontend/app/layout.tsx:0:0-0:0) | Modified - Added NotificationProvider wrapper |
| [frontend/app/providers/__tests__/NotificationProvider.test.tsx](cci:7://file:///home/dsotec/Documents/launchpad/frontend/app/providers/__tests__/NotificationProvider.test.tsx:0:0-0:0) | Created - Unit tests |

## Testing

- All 99 tests pass
- Lint and type-check pass

Closes #160