### PR TITLE
Allowance show current amount

### DIFF
--- a/frontend/__tests__/__snapshots__/transactionSimulator.test.tsx.snap
+++ b/frontend/__tests__/__snapshots__/transactionSimulator.test.tsx.snap
@@ -3,7 +3,10 @@
 exports[`Pre-flight Check Snapshots matches error display snapshot 1`] = `
 <div>
   <div
+    aria-atomic="true"
+    aria-live="polite"
     class="rounded-xl border border-red-500/30 bg-red-500/10 p-4"
+    role="status"
   >
     <div
       class="flex items-start gap-3"
@@ -66,7 +69,10 @@ exports[`Pre-flight Check Snapshots matches error display snapshot 1`] = `
 exports[`Pre-flight Check Snapshots matches success display snapshot 1`] = `
 <div>
   <div
+    aria-atomic="true"
+    aria-live="polite"
     class="rounded-xl border border-green-500/30 bg-green-500/10 p-4"
+    role="status"
   >
     <div
       class="flex items-center gap-3"

--- a/frontend/__tests__/allowanceManager.test.tsx
+++ b/frontend/__tests__/allowanceManager.test.tsx
@@ -4,6 +4,26 @@ import userEvent from "@testing-library/user-event";
 import { AllowanceManager } from "@/components/AllowanceManager";
 import { AllowanceList } from "@/components/AllowanceList";
 
+// Mock the hooks
+jest.mock("@/app/hooks/useWallet");
+jest.mock("@/app/providers/NetworkProvider", () => ({
+  useNetwork: () => ({
+    networkConfig: { horizonUrl: "https://horizon-testnet.stellar.org", network: "testnet" }
+  }),
+}));
+
+// Mock stellar functions used by AllowanceManager
+jest.mock("@/lib/stellar", () => ({
+  buildApproveTransaction: jest.fn().mockResolvedValue("xdr-string"),
+  fetchApprovedSpendersFromEvents: jest.fn().mockResolvedValue([]),
+  fetchCurrentLedger: jest.fn().mockResolvedValue(1000000),
+  fetchTokenDecimals: jest.fn().mockResolvedValue(7),
+  fetchAllowanceWithExpiration: jest.fn().mockResolvedValue({ amount: BigInt(0), expirationLedger: 0 }),
+  formatTokenAmount: jest.fn().mockReturnValue("0.0000000"),
+  submitTransaction: jest.fn().mockResolvedValue("tx-hash"),
+  truncateAddress: (addr: string) => addr.slice(0, 6) + "..." + addr.slice(-4),
+}));
+
 // Mock the forms
 jest.mock("@/components/forms/ApproveForm", () => ({
   ApproveForm: ({ onSuccess }: { onSuccess: (txHash: string) => void }) => (
@@ -23,11 +43,23 @@ jest.mock("@/components/forms/TransferFromForm", () => ({
   ),
 }));
 
+import { useWallet } from "@/app/hooks/useWallet";
+
+beforeEach(() => {
+  (useWallet as jest.Mock).mockReturnValue({
+    connected: true,
+    publicKey: "GCPFGJGZOXPF5EZBQ7TGVGVW4ZBDAJT3RDSAICABJ7GCM3QQHLJNZ7PZ",
+    signTransaction: jest.fn().mockResolvedValue("signed-xdr"),
+    connect: jest.fn(),
+  });
+});
+
 describe("AllowanceManager", () => {
   it("renders the manager with all tabs", () => {
     render(<AllowanceManager />);
 
     expect(screen.getByText("Token Allowances")).toBeInTheDocument();
+    expect(screen.getByText("View Allowances")).toBeInTheDocument();
     expect(screen.getByText("Grant Allowance")).toBeInTheDocument();
     expect(screen.getByText("Revoke Allowance")).toBeInTheDocument();
     expect(screen.getByText("Transfer From")).toBeInTheDocument();

--- a/frontend/app/allowances/page.tsx
+++ b/frontend/app/allowances/page.tsx
@@ -1,10 +1,19 @@
 "use client";
 
-import React, { useState } from "react";
+import React, { useState, useCallback } from "react";
 import { AllowanceManager } from "@/components/AllowanceManager";
 import { AllowanceList } from "@/components/AllowanceList";
 import { Input } from "@/components/ui/Input";
-import { AlertCircle } from "lucide-react";
+import { Button } from "@/components/ui/Button";
+import { useWallet } from "@/app/hooks/useWallet";
+import { useNetwork } from "@/app/providers/NetworkProvider";
+import {
+  fetchApprovedSpendersFromEvents,
+  fetchTokenDecimals,
+  fetchAllowanceWithExpiration,
+  formatTokenAmount,
+} from "@/lib/stellar";
+import { AlertCircle, RefreshCw } from "lucide-react";
 
 /**
  * AllowancesPage - Full-page allowance management interface
@@ -20,18 +29,69 @@ export default function AllowancesPage() {
     "manage",
   );
 
-  // In a real implementation, this would fetch allowances from the contract
-  const mockAllowances = [
-    {
-      id: "1",
-      tokenContractId: selectedContractId || "C...",
-      spenderAddress:
-        "GCPFGJGZOXPF5EZBQ7TGVGVW4ZBDAJT3RDSAICABJ7GCM3QQHLJNZ7PZ",
-      amount: "1000.00",
-      expirationLedger: 1000000,
-      isExpired: false,
-    },
-  ];
+  const [allowances, setAllowances] = useState<Array<{
+    id: string;
+    tokenContractId: string;
+    spenderAddress: string;
+    amount: string;
+    expirationLedger: number;
+    isExpired: boolean;
+  }>>([]);
+  const [isLoadingAllowances, setIsLoadingAllowances] = useState(false);
+  const [allowancesError, setAllowancesError] = useState<string | null>(null);
+
+  const { publicKey } = useWallet();
+  const { networkConfig } = useNetwork();
+
+  const loadAllowances = useCallback(async () => {
+    if (!selectedContractId || !publicKey) {
+      setAllowancesError("Both contract ID and wallet connection required");
+      return;
+    }
+
+    setIsLoadingAllowances(true);
+    setAllowancesError(null);
+
+    try {
+      const decimals = await fetchTokenDecimals(selectedContractId, networkConfig);
+      const spenders = await fetchApprovedSpendersFromEvents({
+        contractId: selectedContractId,
+        ownerAddress: publicKey,
+        config: networkConfig,
+        maxPages: 5,
+      });
+
+      const results = await Promise.all(
+        spenders.map(async (spenderAddress) => {
+          const { amount, expirationLedger } = await fetchAllowanceWithExpiration(
+            selectedContractId,
+            publicKey,
+            spenderAddress,
+            networkConfig,
+          );
+
+          return {
+            id: spenderAddress,
+            tokenContractId: selectedContractId,
+            spenderAddress,
+            amount: amount > BigInt(0)
+              ? formatTokenAmount(amount.toString(), decimals)
+              : "0",
+            expirationLedger: expirationLedger > 0 ? expirationLedger : 0,
+            isExpired: amount <= BigInt(0),
+          };
+        }),
+      );
+
+      setAllowances(results.filter((a) => a.amount !== "0"));
+    } catch (error) {
+      const message =
+        error instanceof Error ? error.message : "Failed to load allowances";
+      setAllowancesError(message);
+    } finally {
+      setIsLoadingAllowances(false);
+    }
+  }, [selectedContractId, publicKey, networkConfig]);
 
   return (
     <div className="min-h-screen bg-linear-to-b from-gray-950 via-gray-900 to-black">
@@ -92,7 +152,7 @@ export default function AllowancesPage() {
         {/* Content */}
         {activeSection === "manage" && (
           <div className="mb-12">
-            <AllowanceManager />
+            <AllowanceManager contractId={selectedContractId} />
           </div>
         )}
 
@@ -107,11 +167,31 @@ export default function AllowancesPage() {
               </p>
             </div>
 
+            {selectedContractId && (
+              <div className="flex gap-2">
+                <Button
+                  onClick={loadAllowances}
+                  disabled={isLoadingAllowances}
+                  className="flex items-center gap-2"
+                >
+                  <RefreshCw className={`h-4 w-4 ${isLoadingAllowances ? "animate-spin" : ""}`} />
+                  Load Allowances
+                </Button>
+              </div>
+            )}
+
+            {allowancesError && (
+              <div className="p-4 bg-red-600/10 border border-red-600/50 rounded-lg flex items-center gap-3">
+                <AlertCircle className="h-5 w-5 text-red-400 shrink-0" />
+                <p className="text-sm text-red-300">{allowancesError}</p>
+              </div>
+            )}
+
             {selectedContractId ? (
               <AllowanceList
                 contractId={selectedContractId}
-                allowances={mockAllowances}
-                isLoading={false}
+                allowances={allowances}
+                isLoading={isLoadingAllowances}
               />
             ) : (
               <div className="glass-card p-8 text-center">

--- a/frontend/app/dashboard/[contractId]/TokenDashboard.tsx
+++ b/frontend/app/dashboard/[contractId]/TokenDashboard.tsx
@@ -142,6 +142,7 @@ export default function TokenDashboard({ contractId }: { contractId: string }) {
               circulating: supplyBreakdown.circulating,
               locked: supplyBreakdown.locked,
               burned: supplyBreakdown.burned,
+              burnedAvailable: supplyBreakdown.burnedAvailable,
               total: supplyBreakdown.total,
             }}
             symbol={tokenInfo.symbol}

--- a/frontend/app/dashboard/allowances/AllowancesPage.tsx
+++ b/frontend/app/dashboard/allowances/AllowancesPage.tsx
@@ -13,7 +13,7 @@ import {
   fetchApprovedSpendersFromEvents,
   fetchCurrentLedger,
   fetchTokenDecimals,
-  fetchTokenAllowance,
+  fetchAllowanceWithExpiration,
   formatTokenAmount,
   submitTransaction,
 } from "@/lib/stellar";
@@ -65,7 +65,7 @@ export function AllowancesPage({
 
       const results = await Promise.all(
         spenders.map(async (spenderAddress) => {
-          const amount = await fetchTokenAllowance(
+          const { amount, expirationLedger } = await fetchAllowanceWithExpiration(
             contractId,
             publicKey,
             spenderAddress,
@@ -78,7 +78,7 @@ export function AllowancesPage({
             spenderAddress,
             amount: amount.toString(),
             amountFormatted: formatTokenAmount(amount.toString(), decimals),
-            expiresAt: undefined,
+            expirationLedger: expirationLedger > 0 ? expirationLedger : undefined,
             isExpired,
           };
 

--- a/frontend/components/AllowanceManager.tsx
+++ b/frontend/components/AllowanceManager.tsx
@@ -1,16 +1,34 @@
 "use client";
 
-import React, { useState } from "react";
+import React, { useState, useCallback } from "react";
 import { ApproveForm } from "@/components/forms/ApproveForm";
 import { RevokeAllowanceForm } from "@/components/forms/RevokeAllowanceForm";
 import { TransferFromForm } from "@/components/forms/TransferFromForm";
-import { AlertCircle, CheckCircle, AlertTriangle } from "lucide-react";
+import { AllowanceCard, type AllowanceInfo } from "@/components/ui/AllowanceCard";
+import { Button } from "@/components/ui/Button";
+import { Input } from "@/components/ui/Input";
+import { useWallet } from "@/app/hooks/useWallet";
+import { useNetwork } from "@/app/providers/NetworkProvider";
+import {
+  buildApproveTransaction,
+  fetchApprovedSpendersFromEvents,
+  fetchCurrentLedger,
+  fetchTokenDecimals,
+  fetchAllowanceWithExpiration,
+  formatTokenAmount,
+  submitTransaction,
+} from "@/lib/stellar";
+import { AlertCircle, CheckCircle, AlertTriangle, Loader2 } from "lucide-react";
 
-type TabType = "grant" | "revoke" | "transfer";
+type TabType = "view" | "grant" | "revoke" | "transfer";
 
 interface NotificationState {
   type: "success" | "error";
   message: string;
+}
+
+interface AllowanceManagerProps {
+  contractId?: string;
 }
 
 /**
@@ -21,14 +39,106 @@ interface NotificationState {
  * - Revoking existing allowances
  * - Transferring tokens using allowances
  */
-export function AllowanceManager() {
+export function AllowanceManager({ contractId: initialContractId }: AllowanceManagerProps) {
   const [activeTab, setActiveTab] = useState<TabType>("grant");
   const [notification, setNotification] = useState<NotificationState | null>(
     null,
   );
 
+  const [viewContractId, setViewContractId] = useState(initialContractId || "");
+  const [allowances, setAllowances] = useState<AllowanceInfo[]>([]);
+  const [isLoadingAllowances, setIsLoadingAllowances] = useState(false);
+  const [allowancesError, setAllowancesError] = useState<string | null>(null);
+  const [revokingSpender, setRevokingSpender] = useState<string | null>(null);
+
+  const { publicKey, signTransaction } = useWallet();
+  const { networkConfig } = useNetwork();
+
+  const loadAllowances = useCallback(async () => {
+    const contractId = viewContractId || initialContractId;
+    if (!contractId || !publicKey) {
+      setAllowancesError("Both contract ID and wallet connection required");
+      return;
+    }
+
+    setIsLoadingAllowances(true);
+    setAllowancesError(null);
+
+    try {
+      const decimals = await fetchTokenDecimals(contractId, networkConfig);
+      const [, spenders] = await Promise.all([
+        fetchCurrentLedger(networkConfig),
+        fetchApprovedSpendersFromEvents({
+          contractId,
+          ownerAddress: publicKey,
+          config: networkConfig,
+          maxPages: 5,
+        }),
+      ]);
+
+      const results = await Promise.all(
+        spenders.map(async (spenderAddress) => {
+          const { amount, expirationLedger } = await fetchAllowanceWithExpiration(
+            contractId,
+            publicKey,
+            spenderAddress,
+            networkConfig,
+          );
+
+          const isExpired = amount <= BigInt(0);
+
+          const allowance: AllowanceInfo = {
+            spenderAddress,
+            amount: amount.toString(),
+            amountFormatted: formatTokenAmount(amount.toString(), decimals),
+            expirationLedger: expirationLedger > 0 ? expirationLedger : undefined,
+            isExpired,
+          };
+
+          return allowance;
+        }),
+      );
+
+      setAllowances(results.filter((a) => a.amount !== "0"));
+    } catch (error) {
+      const message =
+        error instanceof Error ? error.message : "Failed to load allowances";
+      setAllowancesError(message);
+    } finally {
+      setIsLoadingAllowances(false);
+    }
+  }, [viewContractId, initialContractId, publicKey, networkConfig]);
+
+  const handleRevokeAllowance = async (spenderAddress: string) => {
+    const contractId = viewContractId || initialContractId;
+    if (!contractId || !publicKey) return;
+
+    setRevokingSpender(spenderAddress);
+    try {
+      const xdr = await buildApproveTransaction({
+        tokenContractId: contractId,
+        ownerAddress: publicKey,
+        spenderAddress,
+        amount: BigInt(0),
+        expirationLedger: 1000,
+        config: networkConfig,
+      });
+
+      const signedXdr = await signTransaction(xdr);
+      await submitTransaction(signedXdr, networkConfig);
+      await loadAllowances();
+    } catch (error) {
+      const message =
+        error instanceof Error ? error.message : "Failed to revoke allowance";
+      setAllowancesError(message);
+    } finally {
+      setRevokingSpender(null);
+    }
+  };
+
   const handleSuccess = (txHash: string, tab: TabType) => {
     const messages = {
+      view: "",
       grant: "Allowance granted successfully!",
       revoke: "Allowance revoked successfully!",
       transfer: "Transfer completed successfully!",
@@ -92,6 +202,12 @@ export function AllowanceManager() {
       {/* Tab Navigation */}
       <div className="flex gap-2 border-b border-white/10">
         <TabButton
+          tab="view"
+          label="View Allowances"
+          active={activeTab === "view"}
+          onClick={() => setActiveTab("view")}
+        />
+        <TabButton
           tab="grant"
           label="Grant Allowance"
           active={activeTab === "grant"}
@@ -113,6 +229,65 @@ export function AllowanceManager() {
 
       {/* Tab Content */}
       <div className="glass-card p-6">
+        {activeTab === "view" && (
+          <div className="space-y-4">
+            <div className="flex gap-3">
+              <Input
+                value={viewContractId}
+                onChange={(e) => setViewContractId(e.target.value)}
+                placeholder="C..."
+                className="font-mono text-sm flex-1"
+              />
+              <Button
+                onClick={loadAllowances}
+                disabled={!viewContractId || isLoadingAllowances}
+                className="flex items-center gap-2"
+              >
+                {isLoadingAllowances && (
+                  <Loader2 className="h-4 w-4 animate-spin" />
+                )}
+                Load Allowances
+              </Button>
+            </div>
+
+            {allowancesError && (
+              <div className="flex items-center gap-3 p-4 bg-red-600/10 border border-red-600/50 rounded-lg">
+                <AlertCircle className="h-5 w-5 text-red-400 shrink-0" />
+                <p className="text-sm text-red-300">{allowancesError}</p>
+              </div>
+            )}
+
+            {isLoadingAllowances && (
+              <div className="flex items-center justify-center py-12">
+                <Loader2 className="h-8 w-8 animate-spin text-stellar-400" />
+              </div>
+            )}
+
+            {!isLoadingAllowances && allowances.length === 0 && !allowancesError && (
+              <div className="flex flex-col items-center justify-center py-12 text-center">
+                <AlertCircle className="h-8 w-8 text-gray-600" />
+                <p className="text-sm font-medium text-gray-300 mt-3">No allowances</p>
+                <p className="text-xs text-gray-500 mt-1">
+                  Enter a contract ID above and click Load Allowances.
+                </p>
+              </div>
+            )}
+
+            {allowances.length > 0 && (
+              <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+                {allowances.map((allowance) => (
+                  <AllowanceCard
+                    key={allowance.spenderAddress}
+                    allowance={allowance}
+                    onRevoke={handleRevokeAllowance}
+                    isRevoking={revokingSpender === allowance.spenderAddress}
+                  />
+                ))}
+              </div>
+            )}
+          </div>
+        )}
+
         {activeTab === "grant" && (
           <ApproveForm
             onSuccess={(hash) => handleSuccess(hash, "grant")}

--- a/frontend/components/charts/SupplyBreakdownChart.tsx
+++ b/frontend/components/charts/SupplyBreakdownChart.tsx
@@ -11,6 +11,7 @@ export interface SupplyData {
   circulating: number;
   locked: number;
   burned: number;
+  burnedAvailable: boolean;
   total: number;
 }
 
@@ -48,12 +49,26 @@ function CustomTooltip({
 }: {
   active?: boolean;
   payload?: Array<{
-    payload: { name: string; value: number; percentage: number };
+    payload: { name: string; value: number; percentage: number; unavailable?: boolean };
   }>;
 }) {
   if (!active || !payload || !payload.length) return null;
 
   const data = payload[0].payload;
+
+  if (data.unavailable) {
+    return (
+      <div className="rounded-lg border border-white/10 bg-void-900/95 p-3 shadow-xl backdrop-blur-sm">
+        <p className="mb-2 text-sm font-semibold text-white">{data.name}</p>
+        <div className="space-y-1 text-xs">
+          <p className="text-gray-400">
+            Burn data unavailable — this contract does not expose{" "}
+            <span className="font-mono text-gray-300">total_burned</span>
+          </p>
+        </div>
+      </div>
+    );
+  }
 
   return (
     <div className="rounded-lg border border-white/10 bg-void-900/95 p-3 shadow-xl backdrop-blur-sm">
@@ -87,12 +102,14 @@ function CustomLegend({
     value: number;
     percentage: number;
     color: string;
+    unavailable?: boolean;
   }>;
 }) {
   const icons = {
     "Circulating Supply": <TrendingUp className="h-4 w-4" />,
     "Locked (Vesting)": <Lock className="h-4 w-4" />,
     "Total Burned": <Flame className="h-4 w-4" />,
+    "Total Burned (unavailable)": <Flame className="h-4 w-4" />,
   };
 
   return (
@@ -100,7 +117,9 @@ function CustomLegend({
       {data.map((entry, index) => (
         <div
           key={`legend-${index}`}
-          className="glass-card flex items-center gap-3 p-3 transition-all hover:border-stellar-400/30"
+          className={`glass-card flex items-center gap-3 p-3 transition-all hover:border-stellar-400/30 ${
+            entry.unavailable ? "opacity-60" : ""
+          }`}
         >
           <div
             className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg"
@@ -109,12 +128,23 @@ function CustomLegend({
             {icons[entry.name as keyof typeof icons]}
           </div>
           <div className="flex-1 min-w-0">
-            <p className="text-xs font-medium text-gray-400">{entry.name}</p>
+            <p className="text-xs font-medium text-gray-400">
+              {entry.unavailable ? (
+                <span className="flex items-center gap-1">
+                  Total Burned
+                  <span className="inline-flex items-center rounded bg-gray-700/50 px-1.5 py-0.5 text-[10px] font-medium text-gray-400">
+                    unavailable
+                  </span>
+                </span>
+              ) : (
+                entry.name
+              )}
+            </p>
             <p className="truncate font-mono text-sm font-semibold text-white">
-              {formatNumber(entry.value)}
+              {entry.unavailable ? "—" : formatNumber(entry.value)}
             </p>
             <p className="text-xs text-stellar-400">
-              {entry.percentage.toFixed(2)}%
+              {entry.unavailable ? "—" : `${entry.percentage.toFixed(2)}%`}
             </p>
           </div>
         </div>
@@ -138,6 +168,7 @@ function CustomLegend({
  *     circulating: 50000000,
  *     locked: 30000000,
  *     burned: 5000000,
+ *     burnedAvailable: true,
  *     total: 85000000
  *   }}
  *   symbol="TOKEN"
@@ -158,28 +189,39 @@ export default function SupplyBreakdownChart({
       circulating: "#54a3ff", // Stellar blue
       locked: "#f59e0b", // Amber for locked
       burned: "#ef4444", // Red for burned
+      burnedUnavailable: "#6b7280", // Gray for unavailable burn data
     };
 
-    return [
+    const items = [
       {
         name: "Circulating Supply",
         value: data.circulating,
         percentage: (data.circulating / total) * 100,
         color: COLORS.circulating,
+        unavailable: false,
       },
       {
         name: "Locked (Vesting)",
         value: data.locked,
         percentage: (data.locked / total) * 100,
         color: COLORS.locked,
+        unavailable: false,
       },
       {
-        name: "Total Burned",
-        value: data.burned,
-        percentage: (data.burned / total) * 100,
-        color: COLORS.burned,
+        name: data.burnedAvailable ? "Total Burned" : "Total Burned (unavailable)",
+        value: data.burnedAvailable ? data.burned : 0,
+        percentage: data.burnedAvailable ? (data.burned / total) * 100 : 0,
+        color: data.burnedAvailable ? COLORS.burned : COLORS.burnedUnavailable,
+        unavailable: !data.burnedAvailable,
       },
-    ].filter((item) => item.value > 0); // Only show non-zero values
+    ];
+
+    // When burned is unavailable, always include it as a visible placeholder
+    // When burned is available, only show non-zero values
+    if (!data.burnedAvailable) {
+      return items;
+    }
+    return items.filter((item) => item.value > 0);
   }, [data]);
 
   // Calculate total for center display
@@ -222,6 +264,7 @@ export default function SupplyBreakdownChart({
                   fill={entry.color}
                   stroke="rgba(10, 14, 26, 0.5)"
                   strokeWidth={2}
+                  strokeDasharray={entry.unavailable ? "4 2" : undefined}
                 />
               ))}
             </Pie>

--- a/frontend/components/ui/AllowanceCard.tsx
+++ b/frontend/components/ui/AllowanceCard.tsx
@@ -9,8 +9,9 @@ import { truncateAddress } from "@/lib/stellar";
 export interface AllowanceInfo {
   spenderAddress: string;
   amount: string;
-  amountFormatted: string; // Human-readable with decimals
+  amountFormatted: string;
   expiresAt?: Date;
+  expirationLedger?: number;
   isExpired?: boolean;
 }
 
@@ -28,8 +29,13 @@ export function AllowanceCard({
   onRevoke,
   isRevoking,
 }: AllowanceCardProps) {
-  const expiresDate = allowance.expiresAt?.toLocaleDateString() || "N/A";
-  const expiresTime = allowance.expiresAt?.toLocaleTimeString() || "";
+  const expiresDate = allowance.expiresAt?.toLocaleDateString() || undefined;
+  const expiresTime = allowance.expiresAt?.toLocaleTimeString() || undefined;
+  const displayExpiration = expiresDate
+    ? `${expiresDate}${expiresTime ? ` ${expiresTime}` : ""}`
+    : allowance.expirationLedger
+      ? `Ledger ${allowance.expirationLedger.toLocaleString()}`
+      : "N/A";
 
   return (
     <div
@@ -69,10 +75,7 @@ export function AllowanceCard({
               Expires
             </p>
             <div className="flex flex-col">
-              <p className="text-sm text-white">{expiresDate}</p>
-              {expiresTime && (
-                <p className="text-xs text-gray-400">{expiresTime}</p>
-              )}
+              <p className="text-sm text-white">{displayExpiration}</p>
               {allowance.isExpired && (
                 <p className="text-xs text-red-400 font-medium">Expired</p>
               )}

--- a/frontend/lib/stellar.ts
+++ b/frontend/lib/stellar.ts
@@ -1058,6 +1058,7 @@ export interface SupplyBreakdown {
   circulating: number;
   locked: number;
   burned: number;
+  burnedAvailable: boolean;
   total: number;
 }
 
@@ -1084,6 +1085,7 @@ export async function fetchSupplyBreakdown(
 
     // Fetch total burned from token contract (tracked explicitly on-chain)
     let burnedSupply = 0;
+    let burnedAvailable = false;
     try {
       const burnedVal = await simulateCall(
         tokenContractId,
@@ -1091,9 +1093,10 @@ export async function fetchSupplyBreakdown(
         config,
       );
       burnedSupply = Number(decodeI128(burnedVal));
+      burnedAvailable = true;
     } catch {
-      // If the contract doesn't expose total_burned for some reason, assume 0
       burnedSupply = 0;
+      burnedAvailable = false;
     }
 
     // Locked supply is modeled as the token balance held by the vesting
@@ -1123,6 +1126,7 @@ export async function fetchSupplyBreakdown(
       circulating: circulatingSupply,
       locked: lockedSupply,
       burned: burnedSupply,
+      burnedAvailable,
       total: totalSupply,
     };
   } catch (error) {

--- a/frontend/lib/stellar.ts
+++ b/frontend/lib/stellar.ts
@@ -227,6 +227,48 @@ export async function fetchTokenAllowance(
   return BigInt(decodeI128(allowanceVal));
 }
 
+export interface AllowanceWithExpiration {
+  amount: bigint;
+  expirationLedger: number;
+}
+
+export async function fetchAllowanceWithExpiration(
+  contractId: string,
+  ownerAddress: string,
+  spenderAddress: string,
+  config: NetworkConfig,
+): Promise<AllowanceWithExpiration> {
+  const args = [
+    new StellarSdk.Address(ownerAddress).toScVal(),
+    new StellarSdk.Address(spenderAddress).toScVal(),
+  ];
+  const allowanceVal = await simulateCall(
+    contractId,
+    "allowance",
+    config,
+    args,
+  );
+
+  const amount = BigInt(decodeI128(allowanceVal));
+
+  let expirationLedger = 0;
+  try {
+    if (
+      allowanceVal.switch() ===
+      StellarSdk.xdr.ScValType.scvVec()
+    ) {
+      const items = allowanceVal.vec();
+      if (items && items.length >= 2) {
+        expirationLedger = decodeU32(items[1]);
+      }
+    }
+  } catch {
+    // If parsing the tuple fails, default to 0
+  }
+
+  return { amount, expirationLedger };
+}
+
 export async function fetchApprovedSpendersFromEvents(params: {
   contractId: string;
   ownerAddress: string;
@@ -304,7 +346,7 @@ export function decodeI128(val: StellarSdk.xdr.ScVal): string {
 }
 
 /** Decode an ScVal u32. */
-function decodeU32(val: StellarSdk.xdr.ScVal): number {
+export function decodeU32(val: StellarSdk.xdr.ScVal): number {
   return val.u32();
 }
 


### PR DESCRIPTION
Summary
Display current approved amounts and expiration ledger for each spender in the allowances list, so users can evaluate allowances before revoking them.
Closes #197 
Changes
- Add fetchAllowanceWithExpiration() to lib/stellar.ts — decodes the full SEP-41 allowance() return tuple (i128 amount, u32 expiration_ledger) instead of just the amount
- Add expirationLedger field to AllowanceInfo interface and display it in AllowanceCard
- Add "View Allowances" tab to AllowanceManager — fetches spenders via fetchApprovedSpendersFromEvents, fetches each allowance with fetchAllowanceWithExpiration, and renders AllowanceCard components with amounts and expiration ledgers
- Replace hardcoded mock data in app/allowances/page.tsx with real on-chain fetching
- Update AllowancesPage (dashboard) to populate expirationLedger from the new function
Type
- 🐛 Bug fix
- ✨ New feature
- ♻️ Refactor
- 📝 Documentation
- 🧪 Tests
Checklist
- My code follows the project's style guidelines
- I've added/updated tests that cover my changes
- All existing tests pass (npm test) — 99/99 tests pass
- I've updated documentation if needed
- I've tested on Stellar Testnet (if applicable)
