### PR TITLE
fix: early wallet banner in deploy form + vesting auto-discovery from deployments

### DIFF
--- a/frontend/app/deploy/DeployForm.tsx
+++ b/frontend/app/deploy/DeployForm.tsx
@@ -19,7 +19,7 @@ import { useTransactionSimulator } from "@/hooks/useTransactionSimulator";
 import { useWallet } from "@/app/hooks/useWallet";
 import { savePendingMetadata } from "./utils/metadata";
 import { trackDeployment } from "@/lib/deployments";
-import { ArrowLeft, ArrowRight, Rocket } from "lucide-react";
+import { ArrowLeft, ArrowRight, Rocket, Wallet } from "lucide-react";
 import { useNetwork } from "@/app/providers/NetworkProvider";
 import { useToast } from "@/app/providers/ToastProvider";
 import { useDeployToken, type DeployTokenError } from "../hooks/useDeployToken";
@@ -80,7 +80,7 @@ export default function DeployForm() {
   const [cooldownRemainingMs, setCooldownRemainingMs] = useState(0);
 
   const router = useRouter();
-  const { publicKey } = useWallet();
+  const { publicKey, connect } = useWallet();
   const { deployToken } = useDeployToken();
   const COOLDOWN_MS = 60_000;
 
@@ -331,6 +331,20 @@ export default function DeployForm() {
         <p className="sr-only" role="status" aria-live="polite" aria-atomic="true">
           {announcement}
         </p>
+        {!publicKey && currentStep < 4 && (
+          <div className="mb-6 flex items-center gap-3 px-4 py-3 rounded-lg bg-stellar-500/10 border border-stellar-500/20 text-sm">
+            <Wallet className="w-4 h-4 text-stellar-400 shrink-0" />
+            <span className="text-gray-300 flex-1">Connect your wallet before deploying — you can still fill in the form now.</span>
+            <button
+              type="button"
+              onClick={connect}
+              className="text-stellar-400 hover:text-stellar-300 font-semibold text-xs whitespace-nowrap underline"
+            >
+              Connect
+            </button>
+          </div>
+        )}
+
         <div className="grow">
           {currentStep === 1 && (
             <StepMetadata register={register} errors={errors} />

--- a/frontend/app/my-account/PersonalDashboard.tsx
+++ b/frontend/app/my-account/PersonalDashboard.tsx
@@ -197,15 +197,16 @@ export default function PersonalDashboard() {
     [publicKey, fetchAccountOperations],
   );
 
-  // Load vesting schedule
-  const lookupVesting = useCallback(async () => {
-    if (!publicKey || !vestingContractId.trim()) return;
+  // Load vesting schedule by contract ID
+  const doVestingLookup = useCallback(async (contractId: string) => {
+    if (!publicKey || !contractId.trim()) return;
+    setVestingContractId(contractId);
     setVestingLoading(true);
     setVestingError(null);
     setVestingSchedule(null);
     try {
       const [schedule, ledger] = await Promise.all([
-        fetchVestingSchedule(vestingContractId.trim(), publicKey),
+        fetchVestingSchedule(contractId.trim(), publicKey),
         fetchCurrentLedger(),
       ]);
       setVestingSchedule(schedule);
@@ -219,7 +220,11 @@ export default function PersonalDashboard() {
     } finally {
       setVestingLoading(false);
     }
-  }, [publicKey, vestingContractId, fetchVestingSchedule, fetchCurrentLedger]);
+  }, [publicKey, fetchVestingSchedule, fetchCurrentLedger]);
+
+  const lookupVesting = useCallback(async () => {
+    await doVestingLookup(vestingContractId);
+  }, [vestingContractId, doVestingLookup]);
 
   // Initial data load
   useEffect(() => {
@@ -404,13 +409,24 @@ export default function PersonalDashboard() {
                   <span className="text-[10px] text-gray-500 bg-white/5 px-2 py-0.5 rounded uppercase">
                     {token.network}
                   </span>
-                  <Link 
-                    href={`/dashboard/${token.contractId}`}
-                    className="text-xs text-stellar-400 hover:text-stellar-300 flex items-center gap-1 group-hover:translate-x-1 transition-transform"
-                  >
-                    View Dashboard
-                    <ExternalLink className="w-3 h-3" />
-                  </Link>
+                  <div className="flex items-center gap-3">
+                    {token.vestingContractId && (
+                      <button
+                        onClick={() => doVestingLookup(token.vestingContractId!)}
+                        className="text-xs text-stellar-400 hover:text-stellar-300 font-medium"
+                        title="Check vesting schedule for this deployment"
+                      >
+                        Check Vesting
+                      </button>
+                    )}
+                    <Link
+                      href={`/dashboard/${token.contractId}`}
+                      className="text-xs text-stellar-400 hover:text-stellar-300 flex items-center gap-1 group-hover:translate-x-1 transition-transform"
+                    >
+                      View Dashboard
+                      <ExternalLink className="w-3 h-3" />
+                    </Link>
+                  </div>
                 </div>
               </div>
             ))

--- a/frontend/lib/deployments.ts
+++ b/frontend/lib/deployments.ts
@@ -6,6 +6,7 @@ export interface TrackedDeployment {
   symbol: string;
   network: string;
   timestamp: number;
+  vestingContractId?: string;
 }
 
 const STORAGE_KEY_PREFIX = "soropad:deployments:";


### PR DESCRIPTION
Closes #203
Closes #204
Closes #205
Closes #198

## Summary

- **Deploy Form (#204):** Added a compact, non-blocking wallet connection banner that appears on steps 1–3 of the deploy flow. Users are now informed early that a wallet is needed, without being blocked from filling in the form.
- **Personal Dashboard (#198):** Added optional `vestingContractId` field to `TrackedDeployment`. Refactored `lookupVesting` into a shared `doVestingLookup(id)` helper. Token cards in "My Deployed Tokens" now show a **Check Vesting** button when a `vestingContractId` was recorded at deploy time — clicking it pre-fills the vesting contract ID input and triggers the lookup automatically, eliminating manual entry.

## Test plan

- [ ] Open `/deploy` without a connected wallet — confirm the compact banner appears on steps 1, 2, and 3; confirm it disappears after connecting
- [ ] Confirm the banner is absent on step 4 (Review already has its own full-size prompt)
- [ ] On Personal Dashboard, create a `TrackedDeployment` entry with a `vestingContractId` set and confirm the **Check Vesting** button appears on that card
- [ ] Click **Check Vesting** — confirm the vesting contract ID field is pre-filled and the schedule is loaded
- [ ] Confirm token cards without a `vestingContractId` do not show the button