### PR TITLE
feat(deploy): show estimated network fee before signing (#193)

### DIFF
--- a/frontend/app/deploy/DeployForm.tsx
+++ b/frontend/app/deploy/DeployForm.tsx
@@ -345,7 +345,14 @@ export default function DeployForm() {
               control={control}
             />
           )}
-          {currentStep === 4 && <StepReview control={control} />}
+          {currentStep === 4 && (
+            <StepReview
+              control={control}
+              estimatedFee={estimatedFee}
+              feeEstimationLoading={feeEstimationLoading}
+              feeEstimationError={feeEstimationError}
+            />
+          )}
         </div>
 
         {/* Fee Estimation (shown on review step) */}
@@ -431,6 +438,9 @@ export default function DeployForm() {
                       errors: result.errors,
                       warnings: result.warnings,
                     });
+                    if (result.estimatedFee) {
+                      setEstimatedFee(result.estimatedFee);
+                    }
                   } catch (error) {
                     const errorMessage =
                       error instanceof Error ? error.message : "Unknown error";

--- a/frontend/app/deploy/steps/StepReview.tsx
+++ b/frontend/app/deploy/steps/StepReview.tsx
@@ -5,10 +5,13 @@ import { useNetwork } from "@/app/providers/NetworkProvider";
 import * as StellarSdk from "@stellar/stellar-sdk";
 import { useEffect, useState } from "react";
 import { Button } from "@/components/ui/Button";
-import { Wallet } from "lucide-react";
+import { Wallet, Zap } from "lucide-react";
 
 interface StepProps {
     control: Control<DeployFormData>;
+    estimatedFee?: string | null;
+    feeEstimationLoading?: boolean;
+    feeEstimationError?: string | null;
 }
 
 const SummaryItem = ({ label, value }: { label: string; value: string | number | undefined }) => (
@@ -29,7 +32,7 @@ const FlagItem = ({ label, enabled }: { label: string; enabled: boolean }) => (
     </div>
 );
 
-export const StepReview = ({ control }: StepProps) => {
+export const StepReview = ({ control, estimatedFee, feeEstimationLoading, feeEstimationError }: StepProps) => {
     const formData = useWatch({ control });
     const { publicKey, connect } = useWallet();
     const adminModeLabel =
@@ -65,6 +68,38 @@ export const StepReview = ({ control }: StepProps) => {
                 <SummaryItem label="Logo URL" value={formData.logoUrl} />
                 <SummaryItem label="Twitter" value={formData.twitter} />
                 <SummaryItem label="Discord" value={formData.discord} />
+            </div>
+
+            {/* Estimated Network Fee */}
+            <div className="glass-card p-4 border-stellar-400/20">
+              <div className="flex items-center justify-between">
+                <div className="flex items-center gap-3">
+                  <div className="p-2 rounded-lg bg-stellar-400/10">
+                    <Zap className="h-5 w-5 text-stellar-400" />
+                  </div>
+                  <div>
+                    <p className="text-sm font-medium text-white">Estimated Network Fee</p>
+                    <p className="text-xs text-gray-400">Pre-flight simulation cost</p>
+                  </div>
+                </div>
+                <div className="text-right">
+                  {feeEstimationLoading ? (
+                    <div className="flex items-center gap-2">
+                      <div className="animate-spin h-4 w-4 border-2 border-stellar-400 border-t-transparent rounded-full" />
+                      <span className="text-sm text-gray-400">Estimating...</span>
+                    </div>
+                  ) : feeEstimationError ? (
+                    <span className="text-sm text-red-400">Failed to estimate</span>
+                  ) : estimatedFee ? (
+                    <div className="flex items-center gap-1">
+                      <span className="text-xl font-bold text-stellar-400">~{estimatedFee}</span>
+                      <span className="text-sm text-gray-400">XLM</span>
+                    </div>
+                  ) : (
+                    <span className="text-sm text-gray-500">Run "Check" to estimate</span>
+                  )}
+                </div>
+              </div>
             </div>
 
             {(formData.authorizationRequired || formData.authorizationRevocable) && (

--- a/frontend/lib/transactionSimulator.ts
+++ b/frontend/lib/transactionSimulator.ts
@@ -391,40 +391,52 @@ export async function simulateTokenDeployment(
     const sim = await rpc.simulateTransaction(tx);
 
     let estimatedFee = "0.01";
+    let simulationCost = "0.01";
+    let simulationFootprint = "";
     
     if (StellarSdk.rpc.Api.isSimulationSuccess(sim)) {
       try {
         const minResourceFee = Number(sim.minResourceFee || "0");
         const baseFee = Number(StellarSdk.BASE_FEE);
         const totalFee = (minResourceFee + baseFee) / 10_000_000;
-        estimatedFee = totalFee.toFixed(7);
+        estimatedFee = totalFee >= 1 ? totalFee.toFixed(2) : totalFee.toFixed(4);
+        simulationCost = estimatedFee;
+        if (sim.transactionData?.footprint) {
+          simulationFootprint = sim.transactionData.footprint.toString();
+        }
       } catch {
         estimatedFee = "0.01";
       }
     }
 
+    const simulationDetails = {
+      cost: simulationCost,
+      footprint: simulationFootprint,
+    };
+
     // "Contract not found" is the expected outcome for a not-yet-deployed
     // token – it means connectivity and argument encoding are both fine.
     if (StellarSdk.rpc.Api.isSimulationError(sim)) {
       if (isExpectedPreflightError(sim.error)) {
-        return { success: true, warnings: [], errors: [], estimatedFee };
+        return { success: true, warnings: [], errors: [], estimatedFee, simulationDetails };
       }
       const friendlyError = parseSorobanError(sim.error);
-      return { success: false, warnings: [], errors: [friendlyError], estimatedFee };
+      return { success: false, warnings: [], errors: [friendlyError], estimatedFee, simulationDetails };
     }
 
     // An unexpected success (shouldn't happen with placeholder) is fine too.
-    return { success: true, warnings: [], errors: [], estimatedFee };
+    return { success: true, warnings: [], errors: [], estimatedFee, simulationDetails };
   } catch (error) {
     const msg = error instanceof Error ? error.message : String(error);
     if (isExpectedPreflightError(msg)) {
-      return { success: true, warnings: [], errors: [], estimatedFee: "0.01" };
+      return { success: true, warnings: [], errors: [], estimatedFee: "0.01", simulationDetails: { cost: "0.01", footprint: "" } };
     }
     return {
       success: false,
       warnings: [],
       errors: [parseSorobanError(msg)],
       estimatedFee: "0.01",
+      simulationDetails: { cost: "0.01", footprint: "" },
     };
   }
 }


### PR DESCRIPTION
feat(deploy): show estimated network fee before signing (#193)

## Description
Parses the preflight simulation result to extract the estimated network fee and displays it in StepReview next to the Deploy button before the user signs. Users can now see the estimated fee (e.g. "~0.05 XLM") after running the Check simulation, eliminating blind signing. Shows a loading state, error state, and a prompt to run Check when no estimate is available yet.

Closes #193

## Type of Change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Tests (adding or updating tests)
- [ ] Documentation (changes to docs only)

## Changes Made
- Updated `frontend/lib/transactionSimulator.ts` — populated `simulationDetails` with `cost` and `footprint` extracted from the actual RPC simulation response; improved fee formatting to `toFixed(2)` for fees ≥ 1 XLM and `toFixed(4)` for smaller fees (was `toFixed(7)`); all return paths now include `simulationDetails`
- Updated `frontend/app/deploy/DeployForm.tsx` — "Check" button handler now sets `estimatedFee` state from `result.estimatedFee` after a successful simulation; passes `estimatedFee`, `feeEstimationLoading`, and `feeEstimationError` props down to `StepReview`
- Updated `frontend/app/deploy/steps/StepReview.tsx` — accepts new `estimatedFee`, `feeEstimationLoading`, and `feeEstimationError` props; displays an inline fee estimation card showing estimated fee in XLM, a loading spinner during simulation, an error state on failure, and a "Run Check to estimate" prompt when no fee is available yet

## How to Test
1. Start the frontend with `npm run dev` and navigate to the Deploy Token form
2. Fill in valid token parameters and click the "Check" button — confirm a simulation runs successfully
3. Navigate to the StepReview step and confirm the estimated fee card appears showing a value like "~0.05 XLM" next to the Deploy button
4. Confirm that before running Check, the fee card shows a "Run Check to estimate fee" prompt instead
5. Simulate a network error during Check and confirm the fee card shows an error state gracefully
6. Confirm fees ≥ 1 XLM display with 2 decimal places and fees < 1 XLM display with 4 decimal places

## Checklist
### Contract Changes
- [ ] `cargo fmt -- --check` passes
- [ ] `cargo clippy -- -D warnings` passes
- [ ] `cargo test` passes (all tests)
- [ ] New tests written for new functionality
- [ ] No hardcoded values that should be configurable

### Frontend Changes
- [x] `npx tsc --noEmit` passes
- [x] `npm run build` succeeds
- [x] Tested in browser with Freighter wallet
- [x] Responsive design verified

### General
- [x] Code follows project conventions
- [x] Self-reviewed my own code
- [x] No `console.log` or debug code left in
- [x] Branch is up to date with `main`

