### PR TITLE
# fix(token): emit wasm hash in upgrade event (#225)

### DIFF
--- a/contracts/token/src/lib.rs
+++ b/contracts/token/src/lib.rs
@@ -371,8 +371,10 @@ impl TokenContract {
             new_wasm_hash != BytesN::from_array(&env, &[0; 32]),
             "invalid wasm hash"
         );
-        env.deployer().update_current_contract_wasm(new_wasm_hash);
-        env.events().publish((symbol_short!("upgrade"),), true);
+        env.deployer()
+            .update_current_contract_wasm(new_wasm_hash.clone());
+        env.events()
+            .publish((symbol_short!("upgrade"),), new_wasm_hash);
     }
 
     // ── Token operations ────────────────────────────────────────────────


### PR DESCRIPTION


Closes #225

## Problem
`upgrade()` currently publishes an `upgrade` event with payload `true`, which prevents event consumers from determining which WASM hash was installed. This reduces auditability for monitoring and security/compliance review.

## Solution
- Emit the installed `new_wasm_hash` as the `upgrade` event payload.
- Clone the hash so it can be used both for `update_current_contract_wasm(...)` and event emission.

## Testing
- `cargo fmt --all -- --check`
- `cargo test --workspace`
- `cargo build --target wasm32-unknown-unknown --release`