### PR TITLE
fix(token): use distinct event topics for freeze and unfreeze actions…

### DIFF
--- a/contracts/token/src/lib.rs
+++ b/contracts/token/src/lib.rs
@@ -256,7 +256,7 @@ impl TokenContract {
         env.storage()
             .persistent()
             .set(&DataKey::Frozen(addr.clone()), &true);
-        env.events().publish((symbol_short!("freeze"), addr), true);
+        env.events().publish((symbol_short!("freeze"), addr), ());
     }
 
     /// Unfreeze a previously frozen account. Admin only.
@@ -265,7 +265,7 @@ impl TokenContract {
         env.storage()
             .persistent()
             .remove(&DataKey::Frozen(addr.clone()));
-        env.events().publish((symbol_short!("freeze"), addr), false);
+        env.events().publish((symbol_short!("unfreeze"), addr), ());
     }
 
     /// Pause the contract, halting all state-changing operations. Admin only.
@@ -1741,5 +1741,38 @@ mod test {
         // Supply a valid future expiration; the allowance should be stored correctly.
         client.approve(&admin, &spender, &500i128, &100u32);
         assert_eq!(client.allowance(&admin, &spender), 500i128);
+    }
+
+    #[test]
+    fn test_freeze_unfreeze_events() {
+        let (env, client, _admin, user) = setup();
+
+        client.freeze_account(&user);
+        let events = env.events().all();
+        let last_event = events.get(events.len() - 1).unwrap();
+        
+        // Verify freeze event
+        assert_eq!(
+            last_event,
+            (
+                client.address.clone(),
+                (symbol_short!("freeze"), user.clone()).into_val(&env),
+                ().into_val(&env)
+            )
+        );
+
+        client.unfreeze_account(&user);
+        let events = env.events().all();
+        let last_event = events.get(events.len() - 1).unwrap();
+        
+        // Verify unfreeze event
+        assert_eq!(
+            last_event,
+            (
+                client.address.clone(),
+                (symbol_short!("unfreeze"), user.clone()).into_val(&env),
+                ().into_val(&env)
+            )
+        );
     }
 }


### PR DESCRIPTION
Closes #232

Summary
This PR updates the event emission logic for account suspension in the Token contract. Previously, both freeze_account and unfreeze_account shared the same "freeze" topic, distinguishing the action only via a boolean payload. This made off-chain indexing and compliance monitoring inefficient.

What Changed
freeze_account: Updated the event topic to use symbol_short!("freeze") and changed the data payload to an empty tuple ().
unfreeze_account: Updated the event topic to use a distinct symbol_short!("unfreeze") and changed the data payload to an empty tuple ().
Unit Testing: Introduced a new test case test_freeze_unfreeze_events in [contracts/token/src/lib.rs](code-assist-path:c:\Users\HP\Desktop\Stellar\launchpad\contracts\token\src\lib.rs) that verifies both events are emitted with the correct topics and empty data payloads.
Rationale
By moving the action type (freeze vs. unfreeze) from the payload into the topic string:

Indexers can now subscribe to specific suspension events without needing to parse the data segment of the event.
Compliance Tools can more reliably track account status changes.
Consistency: The topic now clearly defines the "what," while the tuple data allows for future extensibility if specific metadata needs to be added later.
Verification Results
Automated Tests
Ran cargo test in the contracts/token directory.

bash
running 1 test
test test::test_freeze_unfreeze_events ... ok
Manual Verification
Confirmed that symbol_short! for "unfreeze" (8 characters) is within the 10-character limit allowed by the Soroban SDK.