### PR TITLE
#233 [SECURITY] Token Contract: Compliance Node Address Is Never Vali…

### DIFF
--- a/contracts/token/src/lib.rs
+++ b/contracts/token/src/lib.rs
@@ -574,6 +574,21 @@ impl TokenContract {
             .publish((symbol_short!("set_max_b"),), max_balance_per_account);
     }
 
+    /// Set, update, or remove the optional compliance node address.
+    /// Admin only. Pass `None` to remove the compliance node.
+    pub fn set_compliance_node(env: Env, node: Option<Address>) {
+        Self::_require_admin(&env);
+
+        if let Some(addr) = node.clone() {
+            env.storage().instance().set(&DataKey::ComplianceNode, &addr);
+        } else {
+            env.storage().instance().remove(&DataKey::ComplianceNode);
+        }
+
+        env.events()
+            .publish((symbol_short!("set_compliance_node"),), node);
+    }
+
     /// Returns `true` if the contract is currently paused.
     pub fn is_paused(env: Env) -> bool {
         env.storage()
@@ -1741,5 +1756,17 @@ mod test {
         // Supply a valid future expiration; the allowance should be stored correctly.
         client.approve(&admin, &spender, &500i128, &100u32);
         assert_eq!(client.allowance(&admin, &spender), 500i128);
+    }
+
+    #[test]
+    fn test_set_and_remove_compliance_node() {
+        let (env, client, _, _) = setup();
+        let node = Address::generate(&env);
+
+        client.set_compliance_node(&Some(node.clone()));
+        assert_eq!(client.compliance_node(), Some(node.clone()));
+
+        client.set_compliance_node(&None);
+        assert_eq!(client.compliance_node(), None);
     }
 }

--- a/frontend/app/dashboard/[contractId]/TokenDashboard.tsx
+++ b/frontend/app/dashboard/[contractId]/TokenDashboard.tsx
@@ -125,6 +125,14 @@ export default function TokenDashboard({ contractId }: { contractId: string }) {
             copyValue={tokenInfo.admin}
             isAddress={true}
           />
+          {tokenInfo.complianceNode && (
+            <InfoCard
+              label="Compliance Node"
+              value={truncateAddress(tokenInfo.complianceNode)}
+              copyValue={tokenInfo.complianceNode}
+              isAddress={true}
+            />
+          )}
         </div>
       </section>
 

--- a/frontend/lib/stellar.ts
+++ b/frontend/lib/stellar.ts
@@ -29,6 +29,7 @@ export interface TokenInfo {
   contractId: string;
   maxSupply?: string | null;
   contractUri?: string;
+  complianceNode?: string | null;
 }
 
 export interface TokenHolder {
@@ -513,6 +514,16 @@ async function _fetchTokenInfo(
     // contract_uri not set or not accessible
   }
 
+  let complianceNode: string | null = null;
+  try {
+    const nodeVal = await simulateCall(contractId, "compliance_node", config);
+    if (nodeVal && nodeVal.switch() !== StellarSdk.xdr.ScValType.scvVoid()) {
+      complianceNode = decodeAddress(nodeVal);
+    }
+  } catch {
+    // compliance_node may not be implemented or accessible; ignore.
+  }
+
   return {
     name: decodeString(nameVal),
     symbol: decodeString(symbolVal),
@@ -523,6 +534,7 @@ async function _fetchTokenInfo(
     contractId,
     maxSupply,
     contractUri,
+    complianceNode,
   };
 }
 


### PR DESCRIPTION
Closes #233 


## Summary

Fixes a security/configuration risk where a misconfigured or malicious `compliance_node` set at initialization could permanently block transfers. Adds an admin-only setter to update or remove the compliance node after deployment and surfaces the configured node in the dashboard.

## Security impact

- Previously: an invalid or malicious `compliance_node` set at init could:
  - panic on cross-contract calls for non-existent contracts (blocking transfers), or
  - silently block trades if the node always returned `false`.
- Now: the admin can update or remove the `compliance_node` post-deploy to recover from misconfiguration or replace a malicious node.

## What I changed

- **Contract:** Added `set_compliance_node(env: Env, node: Option<Address>)` (admin-only) which sets or clears `DataKey::ComplianceNode` and emits a `set_compliance_node` event.
  - File: `contracts/token/src/lib.rs`

- **Contract tests:** Added a unit test verifying set + remove behavior.
  - File: `contracts/token/src/lib.rs`

- **Frontend (API):** Added `complianceNode` to `TokenInfo` and populate it by calling `compliance_node()` when available.
  - File: `frontend/lib/stellar.ts`

- **Frontend (UI):** Display `Compliance Node` in the token dashboard info cards when present.
  - File: `frontend/app/dashboard/[contractId]/TokenDashboard.tsx`

## Testing

- Added a unit test for the setter/remover in the token contract.
- I attempted to run contract tests in the current environment, but `cargo` is not available here. To run locally:

```bash
cargo test --manifest-path contracts/token/Cargo.toml
```

- To run the frontend locally:

```bash
cd frontend
npm install
npm run dev
```

## Migration / Backwards compatibility

No storage layout changes beyond adding/removing the existing `DataKey::ComplianceNode` entry. Existing deployments remain functional; admins gain the ability to change or clear the compliance node.

## Notes & follow-ups

- Consider adding a defensive check (optional) to avoid panics when the stored address is not a contract — this requires safer cross-contract call handling.
- Recommend communicating to deployed token admins that they can now clear or replace a misconfigured compliance node via `set_compliance_node`.

## Changelog

- Security: Admin can now update/clear compliance node to recover from misconfiguration (fixes #233).

