### PR TITLE
fix(#231): include previous cliff value in extend_cliff event payload

### DIFF
--- a/contracts/vesting/src/lib.rs
+++ b/contracts/vesting/src/lib.rs
@@ -369,11 +369,14 @@ impl VestingContract {
             "new_cliff must be before end_ledger"
         );
 
+        // Capture old value before mutation
+        let old_cliff = schedule.cliff_ledger;
         schedule.cliff_ledger = new_cliff;
         env.storage().persistent().set(&key, &schedule);
 
+        // Emit event with tuple payload
         env.events()
-            .publish((symbol_short!("clf_ext"), recipient), new_cliff);
+            .publish((symbol_short!("clf_ext"), recipient), (old_cliff, new_cliff));
     }
 
     // ── Read-only queries ───────────────────────────────────────────────
@@ -1039,6 +1042,17 @@ mod test {
         let schedule = get_schedule_latest(&client, &recipient);
         assert_eq!(schedule.cliff_ledger, 150);
         assert_eq!(schedule.end_ledger, 200); // unchanged
+
+        // Verify event emission contains (old_cliff, new_cliff)
+        use soroban_sdk::IntoVal;
+        assert_eq!(
+            env.events().all().last(),
+            Some((
+                contract_id,
+                (symbol_short!("clf_ext"), recipient).into_val(&env),
+                (100u32, 150u32).into_val(&env)
+            ))
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

This PR addresses an issue where the `extend_cliff` event fails to log the historical state transition. By capturing the existing cliff value before it is overwritten in contract storage, the event payload now includes a tuple of both the previous and new cliff values. This ensures accurate audit trails for off-chain indexers and user interfaces.

**Closes #231**

## Changes

- [x] Captured `old_cliff` value from the vesting schedule prior to updating the state in `contracts/vesting/src/lib.rs`.
- [x] Updated the `clf_ext` event emission payload to publish a tuple of `(old_cliff, new_cliff)`.
- [x] Updated the `test_extend_cliff_success` test assertion to validate the new tuple event structure.

## Type

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] ♻️ Refactor
- [ ] 📝 Documentation
- [x] 🧪 Tests

## Checklist

- [x] My code follows the project's style guidelines
- [x] I've added/updated tests that cover my changes
- [ ] All existing tests pass (`cargo test` / `npm test`) *[Note: Relying on remote CI toolchain to run tests due to missing local cargo binary]*
- [ ] I've updated documentation if needed
- [ ] I've tested on Stellar Testnet (if applicable)

## Screenshots / Recordings