### PR TITLE
fix(vesting): enforce pause guard in extend_cliff

### DIFF
--- a/contracts/vesting/src/lib.rs
+++ b/contracts/vesting/src/lib.rs
@@ -351,6 +351,7 @@ impl VestingContract {
     ///   already passed there is nothing left to delay).
     /// - `new_cliff` must remain strictly less than `end_ledger`.
     pub fn extend_cliff(env: Env, recipient: Address, new_cliff: u32, index: Option<u32>) {
+        Self::_check_paused(&env);
         Self::_require_admin(&env);
 
         let (key, mut schedule) = Self::_load_schedule(&env, &recipient, index);
@@ -1108,6 +1109,21 @@ mod test {
         // Clear auths so the next call fails
         env.set_auths(&[]);
         client.extend_cliff(&recipient, &150u32, &latest_index());
+    }
+
+    #[test]
+    #[should_panic(expected = "vesting contract is paused")]
+    fn test_extend_cliff_blocked_when_paused() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let contract_id = env.register_contract(None, VestingContract);
+        let client = VestingContractClient::new(&env, &contract_id);
+        let (_, recipient) = setup_schedule(&env, &client);
+
+        client.pause();
+        // Must panic: "vesting contract is paused"
+        extend_cliff_latest(&client, &recipient, 150u32);
     }
 
     #[test]


### PR DESCRIPTION
Closes #266 

<html>
<body>
<!--StartFragment--><html><head></head><body><h1>fix(vesting): enforce pause guard in <code>extend_cliff</code></h1>
<h2>Summary</h2>
<p><code>extend_cliff</code> was missing a <code>_check_paused</code> call, allowing an admin to mutate
a schedule's cliff ledger while the circuit breaker was engaged. This PR adds
the guard and a regression test to prevent the issue from recurring.</p>
<hr>
<h2>Problem</h2>
<p>Every mutating entry point in the vesting contract — <code>create_schedule</code>,
<code>release</code>, and <code>revoke</code> — calls <code>Self::_check_paused(&amp;env)</code> before performing
any state changes. <code>extend_cliff</code> did not, meaning the pause state had no effect
on it. An admin could silently push a cliff date outward during a security pause,
undermining the purpose of the circuit breaker.</p>
<p><strong>Affected file:</strong> <code>contracts/vesting/src/lib.rs</code>, lines 353–380</p>
<p><strong>Before:</strong></p>
<pre><code class="language-rust">pub fn extend_cliff(env: Env, recipient: Address, new_cliff: u32, index: Option&lt;u32&gt;) {
    Self::_require_admin(&amp;env);
    // ... rest of function
}
</code></pre>
<p>The pause state was never checked, so a paused contract still allowed cliff
extension.</p>
<hr>
<h2>Fix</h2>
<p>Added <code>Self::_check_paused(&amp;env)</code> as the first line of <code>extend_cliff</code>, before
<code>_require_admin</code>, matching the ordering used by <code>revoke</code>.</p>
<p><strong>After:</strong></p>
<pre><code class="language-rust">pub fn extend_cliff(env: Env, recipient: Address, new_cliff: u32, index: Option&lt;u32&gt;) {
    Self::_check_paused(&amp;env);
    Self::_require_admin(&amp;env);
    // ... rest of function
}
</code></pre>
<h3>Guard ordering rationale</h3>
<p><code>revoke</code> uses <code>_check_paused</code> → <code>_require_admin</code>. This PR matches that order for
two reasons:</p>
<ul>
<li><strong>Fail fast on the circuit breaker.</strong> If the contract is paused, reject
immediately without touching auth — cheaper on compute and semantically correct
(a paused contract refuses all mutations regardless of caller).</li>
<li><strong>Consistency.</strong> All admin-only mutating functions now follow the same pattern,
making the guard contract easier to audit.</li>
</ul>
<hr>
<h2>Test added</h2>
<p>A new <code>#[should_panic]</code> test pins the fix so it cannot be silently reverted:</p>
<pre><code class="language-rust">#[test]
#[should_panic(expected = "vesting contract is paused")]
fn test_extend_cliff_blocked_when_paused() {
    let env = Env::default();
    env.mock_all_auths();

    let contract_id = env.register_contract(None, VestingContract);
    let client = VestingContractClient::new(&amp;env, &amp;contract_id);
    let (_, recipient) = setup_schedule(&amp;env, &amp;client);

    client.pause();
    // Must panic: "vesting contract is paused"
    extend_cliff_latest(&amp;client, &amp;recipient, 150u32);
}
</code></pre>
<p>All pre-existing <code>extend_cliff</code> tests continue to pass unchanged:</p>

Test | Status
-- | --
test_extend_cliff_success | ✅ passing
test_extend_cliff_cannot_reduce | ✅ passing
test_extend_cliff_after_cliff_passed | ✅ passing
test_extend_cliff_non_admin_panics | ✅ passing
test_extend_cliff_blocked_when_paused | ✅ new — passing


<hr>
<h2>Checklist</h2>
<ul>
<li>[x] Bug reproduced locally before fix</li>
<li>[x] Fix matches guard ordering used by <code>revoke</code></li>
<li>[x] Regression test added with exact panic message assertion</li>
<li>[x] All existing tests pass</li>
<li>[x] No logic changes outside the guard insertion</li>
<li>[x] No new dependencies introduced</li>
</ul></body></html><!--EndFragment-->
</body>
</html>