### PR TITLE
fix: pass all 9 args to token initialize() — fix ABI mismatch

### DIFF
--- a/frontend/app/deploy/DeployForm.tsx
+++ b/frontend/app/deploy/DeployForm.tsx
@@ -202,6 +202,9 @@ export default function DeployForm() {
         initialSupply: data.initialSupply,
         maxSupply: data.maxSupply,
         adminAddress: data.adminAddress,
+        authorizationRequired: data.authorizationRequired ?? false,
+        authorizationRevocable: data.authorizationRevocable ?? false,
+        complianceNodeAddress: data.complianceNodeAddress || undefined,
       });
 
       setPreflightResult({

--- a/frontend/app/hooks/useDeployToken.ts
+++ b/frontend/app/hooks/useDeployToken.ts
@@ -39,6 +39,9 @@ export interface DeployTokenParams {
   initialSupply: number;
   maxSupply?: number;
   adminAddress: string;
+  authorizationRequired?: boolean;
+  authorizationRevocable?: boolean;
+  complianceNodeAddress?: string;
 }
 
 export interface DeployTokenResult {
@@ -336,6 +339,19 @@ async function initializeContract(
   const maxSupplyScVal = params.maxSupply
     ? StellarSdk.nativeToScVal(params.maxSupply, { type: "i128" })
     : StellarSdk.xdr.ScVal.scvVoid();
+  const authorizationRequiredScVal = StellarSdk.nativeToScVal(
+    params.authorizationRequired ?? false,
+    { type: "bool" },
+  );
+  const authorizationRevocableScVal = StellarSdk.nativeToScVal(
+    params.authorizationRevocable ?? false,
+    { type: "bool" },
+  );
+  const complianceNodeScVal =
+    params.complianceNodeAddress &&
+    params.complianceNodeAddress.trim().length > 0
+      ? new StellarSdk.Address(params.complianceNodeAddress.trim()).toScVal()
+      : StellarSdk.xdr.ScVal.scvVoid();
 
   const initTx = new StellarSdk.TransactionBuilder(sourceAccount, {
     fee: StellarSdk.BASE_FEE,
@@ -349,7 +365,10 @@ async function initializeContract(
         nameScVal,
         symbolScVal,
         initialSupplyScVal,
-        maxSupplyScVal
+        maxSupplyScVal,
+        authorizationRequiredScVal,
+        authorizationRevocableScVal,
+        complianceNodeScVal,
       )
     )
     .setTimeout(30)


### PR DESCRIPTION
The frontend's `initializeContract()` in `useDeployToken.ts` was building the `initialize` call with only 6 arguments (admin, decimal, name, symbol, initial_supply, max_supply), but the contract's `initialize()` function in `contracts/token/src/lib.rs` now takes 9 parameters — it gained `authorization_required: bool`, `authorization_revocable: bool`, and `compliance_node: Option<Address>`.

This caused every deployment to fail at the initialize step after the contract had already been created on-chain, wasting the deploy transaction.

Changes:
- Extend `DeployTokenParams` with optional `authorizationRequired`, `authorizationRevocable`, and `complianceNodeAddress` fields. Defaults (false, false, None) ensure backward compatibility.
- Encode the 3 new args using the same `nativeToScVal` / `Address.toScVal()` / `scvVoid()` pattern already proven in `transactionSimulator.ts`.
- Wire the deploy wizard's existing form fields (StepAdmin) through to the `deployToken()` call in `DeployForm.tsx`.

Files changed:
  frontend/app/hooks/useDeployToken.ts frontend/app/deploy/DeployForm.tsx

Closes #251