### PR TITLE
fix(token): validate decimal range in initialize()

### DIFF
--- a/contracts/token/src/lib.rs
+++ b/contracts/token/src/lib.rs
@@ -83,6 +83,8 @@ impl TokenContract {
             panic!("already initialized");
         }
 
+        assert!(decimal <= 18, "decimals must be <= 18");
+
         if let Some(cap) = max_supply {
             assert!(cap > 0, "max_supply must be positive");
             assert!(initial_supply <= cap, "initial_supply exceeds max_supply");

--- a/contracts/token/tests/fuzz_tests.rs
+++ b/contracts/token/tests/fuzz_tests.rs
@@ -439,3 +439,54 @@ fn test_mint_exceeds_max_supply_rejected() {
     // Remaining capacity is 500_0000000 — minting 1 more overflows the cap.
     client.mint(&user, &(500_0000001i128));
 }
+
+// ===========================================================================
+// Decimal range validation (issue #261)
+// ===========================================================================
+
+#[test]
+#[should_panic(expected = "decimals must be <= 18")]
+fn test_initialize_rejects_decimals_above_18() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let id = env.register_contract(None, TokenContract);
+    let client = TokenContractClient::new(&env, &id);
+    let admin = Address::generate(&env);
+
+    client.initialize(
+        &admin,
+        &19u32,
+        &String::from_str(&env, "BadToken"),
+        &String::from_str(&env, "BAD"),
+        &0i128,
+        &None,
+        &false,
+        &false,
+        &None,
+    );
+}
+
+#[test]
+fn test_initialize_accepts_decimals_at_boundary() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let id = env.register_contract(None, TokenContract);
+    let client = TokenContractClient::new(&env, &id);
+    let admin = Address::generate(&env);
+
+    client.initialize(
+        &admin,
+        &18u32,
+        &String::from_str(&env, "EdgeToken"),
+        &String::from_str(&env, "EDG"),
+        &0i128,
+        &None,
+        &false,
+        &false,
+        &None,
+    );
+
+    assert_eq!(client.decimals(), 18u32);
+}


### PR DESCRIPTION
## Summary

- Adds `assert!(decimal <= 18, "decimals must be <= 18")` in `initialize()` before any storage writes
- Values above 18 cause `10^decimals` to overflow `i128` and produce `Infinity` in JS frontends; SEP-41 tooling assumes a sane range
- Two tests added: one `#[should_panic]` for `decimal = 19`, one happy-path boundary test for `decimal = 18`

## Test plan

- [ ] `cargo test` in `contracts/token` — all 98 tests pass
- [ ] `test_initialize_rejects_decimals_above_18` panics with `"decimals must be <= 18"`
- [ ] `test_initialize_accepts_decimals_at_boundary` passes and `client.decimals()` returns `18`

## Closes

Closes #261
Closes #252
Closes #255
Closes #262