### PR TITLE
fix: AdminPanel fractional BigInt crash, batch mint console.log, and vesting pause guard

### DIFF
--- a/frontend/app/dashboard/[contractId]/components/AdminPanel.tsx
+++ b/frontend/app/dashboard/[contractId]/components/AdminPanel.tsx
@@ -248,7 +248,7 @@ export function AdminPanel({ contractId, maxSupply, totalSupply, decimals }: Adm
 
             // Prepare ScVals for the new mint_batch function
             const addressesScVal = nativeToScVal(entries.map(e => new Address(e.address)), { type: "vec" });
-            const amountsScVal = nativeToScVal(entries.map(e => BigInt(e.amount) * BigInt(10) ** BigInt(decimals)), { type: "vec" });
+            const amountsScVal = nativeToScVal(entries.map(e => BigInt(Math.round(parseFloat(e.amount) * 10 ** decimals))), { type: "vec" });
 
             const tx = new TransactionBuilder(account, {
                 fee: "1000",
@@ -259,7 +259,6 @@ export function AdminPanel({ contractId, maxSupply, totalSupply, decimals }: Adm
                 .build();
 
             const xdrEncoded = tx.toXDR();
-            console.log(`Signing batch mint tx for ${contractId} with ${entries.length} recipients`);
 
             let signedXdr: string;
             try {
@@ -326,7 +325,7 @@ export function AdminPanel({ contractId, maxSupply, totalSupply, decimals }: Adm
                 const mintData = data as MintData;
                 method = "mint";
                 const scaledAmount =
-                    BigInt(mintData.amount) * BigInt(10) ** BigInt(decimals);
+                    BigInt(Math.round(parseFloat(mintData.amount) * 10 ** decimals));
                 args = [addressToScVal(mintData.to), i128ToScVal(scaledAmount)];
 
                 simulationResult = await simulator.checkMint(
@@ -340,7 +339,7 @@ export function AdminPanel({ contractId, maxSupply, totalSupply, decimals }: Adm
                 const burnData = data as BurnData;
                 method = "clawback";
                 const scaledAmount =
-                    BigInt(burnData.amount) * BigInt(10) ** BigInt(decimals);
+                    BigInt(Math.round(parseFloat(burnData.amount) * 10 ** decimals));
                 args = [addressToScVal(burnData.from), i128ToScVal(scaledAmount)];
 
                 simulationResult = await simulator.simulateContract(
@@ -386,7 +385,7 @@ export function AdminPanel({ contractId, maxSupply, totalSupply, decimals }: Adm
                 const endLedger = cliffLedger + durationLedgers;
 
                 const scaledAmount =
-                    BigInt(vestingData.amount) * BigInt(10) ** BigInt(decimals);
+                    BigInt(Math.round(parseFloat(vestingData.amount) * 10 ** decimals));
 
                 args = [
                     addressToScVal(vestingData.recipient),


### PR DESCRIPTION
## Summary

- **#270** — Replace `BigInt(amount) * BigInt(10) ** BigInt(decimals)` with `BigInt(Math.round(parseFloat(amount) * 10 ** decimals))` across all four scaling sites in `AdminPanel.tsx` (mint, clawback, batch mint, vesting). `BigInt("10.5")` throws a `RangeError`; the new approach matches the pattern already used in `TransferPanel`.
- **#271** — Remove the leftover `console.log(\`Signing batch mint tx for ${contractId} with ${entries.length} recipients\`)` that leaked transaction metadata to the console on every batch mint.
- **#264** — `create_schedules_batch()` in `contracts/vesting/src/lib.rs` already has `Self::_check_paused(&env);` as its first statement (merged via PR #286). Confirmed fixed; no code change needed.

## Test plan

- [ ] Enter a fractional amount (e.g. `10.5`) in the Mint, Clawback, and Create Vesting forms — should submit without a RangeError
- [ ] Enter a fractional amount in a batch mint CSV/textarea row — should submit without a RangeError
- [ ] Open browser DevTools console and trigger a batch mint — no metadata log should appear
- [ ] Verify integer amounts still scale correctly (no regression)
- [ ] Confirm `create_schedules_batch` on a paused vesting contract panics (covered by existing Rust tests)

Closes #270
Closes #271
Closes #264