### PR TITLE
fix: burn() now checks frozen status like burn_self()

### DIFF
--- a/contracts/token/src/lib.rs
+++ b/contracts/token/src/lib.rs
@@ -142,8 +142,8 @@ impl TokenContract {
     }
 
     /// Burn `amount` tokens from `from`. Owner only (standard burn).
-    /// Refuses to run when the account is frozen so a holder cannot dodge a freeze
-    /// by destroying tokens.
+    /// Refuses to run when the account is frozen so a holder cannot
+    /// dodge a freeze by destroying tokens.
     pub fn burn(env: Env, from: Address, amount: i128) {
         Self::_check_paused(&env);
         from.require_auth();


### PR DESCRIPTION
Closes #217

## Description
Added frozen account check to `burn()` to match `burn_self()`. A frozen account could previously call `burn()` to destroy their tokens and circumvent the freeze.

## Changes
- Added `assert!(!Self::_is_frozen(&env, &from), "account is frozen");` to `burn()`
- Added `test_burn_blocked_when_frozen` test