### PR TITLE
fix(#307): replace hardcoded expiration ledger with live getLatestLed…

### DIFF
--- a/frontend/components/AllowanceList.tsx
+++ b/frontend/components/AllowanceList.tsx
@@ -17,6 +17,7 @@ interface AllowanceListProps {
   contractId?: string;
   allowances?: Allowance[];
   isLoading?: boolean;
+  currentLedger?: number;
   onRevoke?: (spenderId: string) => Promise<void>;
 }
 
@@ -33,10 +34,24 @@ export function AllowanceList({
   contractId,
   allowances = [],
   isLoading = false,
+  currentLedger,
   onRevoke,
 }: AllowanceListProps) {
   const [revoking, setRevoking] = useState<string | null>(null);
   const [copied, setCopied] = useState<string | null>(null);
+
+  const ledgerToExpiryInfo = (expirationLedger: number): { date: string; countdown: string } | null => {
+    if (currentLedger === undefined) return null;
+    const ledgersRemaining = expirationLedger - currentLedger;
+    const secondsRemaining = ledgersRemaining * 5;
+    const expiryDate = new Date(Date.now() + secondsRemaining * 1000);
+    const dateStr = expiryDate.toLocaleDateString(undefined, { year: "numeric", month: "short", day: "numeric" });
+    if (ledgersRemaining <= 0) return { date: dateStr, countdown: "Expired" };
+    const days = Math.floor(secondsRemaining / 86400);
+    const hours = Math.floor((secondsRemaining % 86400) / 3600);
+    const countdown = days > 0 ? `${days}d ${hours}h remaining` : `${hours}h remaining`;
+    return { date: dateStr, countdown };
+  };
 
   const handleCopy = (text: string, id: string) => {
     navigator.clipboard.writeText(text);
@@ -150,6 +165,14 @@ export function AllowanceList({
                 <p className="text-sm text-gray-300">
                   {allowance.expirationLedger.toLocaleString()}
                 </p>
+                {ledgerToExpiryInfo(allowance.expirationLedger) && (() => {
+                  const expiry = ledgerToExpiryInfo(allowance.expirationLedger)!;
+                  return (
+                    <p className="text-xs text-gray-400 mt-0.5">
+                      {expiry.date} &middot; {expiry.countdown}
+                    </p>
+                  );
+                })()}
               </div>
             </div>
 

--- a/frontend/components/forms/ApproveForm.tsx
+++ b/frontend/components/forms/ApproveForm.tsx
@@ -9,7 +9,7 @@ import { Input } from "@/components/ui/Input";
 import { PreflightCheckDisplay } from "@/components/ui/PreflightCheck";
 import { useTransactionSimulator } from "@/hooks/useTransactionSimulator";
 import { useWallet } from "@/app/hooks/useWallet";
-import { buildApproveTransaction, fetchTokenDecimals, parseTokenAmount, submitTransaction } from "@/lib/stellar";
+import { buildApproveTransaction, fetchCurrentLedger, fetchTokenDecimals, parseTokenAmount, submitTransaction } from "@/lib/stellar";
 import { useNetwork } from "@/app/providers/NetworkProvider";
 import { AlertCircle, CheckCircle, Rocket, Loader2 } from "lucide-react";
 
@@ -65,6 +65,11 @@ export function ApproveForm({ onSuccess, onError }: ApproveFormProps) {
 
   const formData = watch();
 
+  const getExpirationLedger = async (days: string): Promise<number> => {
+    const currentLedger = await fetchCurrentLedger(networkConfig);
+    return currentLedger + parseInt(days || "365") * 17280;
+  };
+
   const handleCheck = async () => {
     const isValid = await trigger();
     if (!isValid) return;
@@ -72,7 +77,7 @@ export function ApproveForm({ onSuccess, onError }: ApproveFormProps) {
     setPreflightResult({ isLoading: true, success: false, errors: [], warnings: [] });
 
     try {
-      const ledger = 1000000 + parseInt(formData.expirationDays || "365") * 10800; // ~10.8s per ledger
+      const ledger = await getExpirationLedger(formData.expirationDays);
       const decimals = await fetchTokenDecimals(formData.tokenContractId, simulator.networkConfig);
       const rawAmount = parseTokenAmount(formData.amount, decimals);
       const result = await simulator.checkApprove(
@@ -114,8 +119,7 @@ export function ApproveForm({ onSuccess, onError }: ApproveFormProps) {
 
     setIsSubmitting(true);
     try {
-      const expirationLedger =
-        1000000 + parseInt(formData.expirationDays || "365") * 10800; // ~10.8s per ledger
+      const expirationLedger = await getExpirationLedger(formData.expirationDays);
       const decimals = await fetchTokenDecimals(formData.tokenContractId, simulator.networkConfig);
       const rawAmount = parseTokenAmount(formData.amount, decimals);
 


### PR DESCRIPTION
Closes #307 

## fix(#307): ApproveForm — replace hardcoded expiration ledger with live ledger sequence

### Problem

Both the simulate (`handleCheck`) and submit (`onSubmit`) paths in
`ApproveForm.tsx` computed the SEP-41 `expiration_ledger` using a
hardcoded base of `1_000_000`:

```ts
// Before (broken)
const ledger = 1000000 + parseInt(formData.expirationDays || "365") * 10800;
```

This caused two compounding bugs:

1. **Stale base** — Testnet and Mainnet ledger sequences are well above
   `1,000,000`. The computed ledger was already in the past, so Soroban
   rejected the allowance (or created one that expired immediately).
2. **Wrong rate** — `10800 ledgers/day` assumes ~8 s/ledger
   (`86400 / 10800 = 8`). Soroban closes ledgers at ~5 s, so the
   allowance window was off by ~60%.

The vesting flow in `AdminPanel` already handles this correctly
(`getLatestLedger().sequence + days * 17280`). `ApproveForm` was the
outlier.

### Fix

**`frontend/components/forms/ApproveForm.tsx`**

- Import `fetchCurrentLedger` from `@/lib/stellar`.
- Add a single shared `getExpirationLedger(days)` helper that calls
  `fetchCurrentLedger(networkConfig)` and returns
  `currentLedger + parseInt(days) * 17280`.
- Both `handleCheck` (simulate) and `onSubmit` (submit) now call the
  same helper — they cannot drift.

```ts
// After (correct)
const getExpirationLedger = async (days: string): Promise<number> => {
  const currentLedger = await fetchCurrentLedger(networkConfig);
  return currentLedger + parseInt(days || "365") * 17280;
};
```

**`frontend/components/AllowanceList.tsx`** *(follow-on)*

- Add optional `currentLedger?: number` prop to `AllowanceListProps`.
- Add `ledgerToExpiryInfo(expirationLedger)` helper that converts a
  ledger number to a human-readable expiry date and countdown string
  (e.g. `Jun 30, 2026 · 364d 23h remaining` / `Expired`) using
  `5 s/ledger` arithmetic.
- Rendered below the existing raw ledger number when `currentLedger`
  is supplied (fully backwards-compatible — callers that don't pass the
  prop see no change).

### Testing

- Set "365 days" in the Approve form → preflight check and submit both
  compute `sequence + 6,
