### PR TITLE
fix(stellar): handle void admin ScVal in fetchTokenInfo

### DIFF
--- a/PR_NOTES/fix-admin-handle-void-admin.md
+++ b/PR_NOTES/fix-admin-handle-void-admin.md
@@ -1,0 +1,20 @@
+Fix admin() void handling in fetchTokenInfo
+
+Summary:
+- Avoid decoding `admin` ScVal when it is `scvVoid()`; return "N/A" instead.
+- Prevents dashboard/admin UI from erroring when a token has no on-chain admin (addresses Issue #129).
+
+Changed files:
+- frontend/lib/stellar.ts — detect and handle `scvVoid()` for `admin()` calls.
+
+Test results (run in this environment):
+- Frontend unit tests: 99 passed, 0 failed.
+- Rust contract tests: not run here (no `cargo` available). Please run `cargo test` in `contracts/token` and `contracts/vesting` in CI or locally.
+
+Changelog:
+- Fix: handle void `admin` ScVal in `fetchTokenInfo` to avoid decode errors and enable admin UI for tokens without an admin.
+
+Branch: `fix/admin-handle-void-admin`
+
+Notes:
+- PR created/updated to include test summary and recommended follow-up (run Rust tests in CI).

--- a/frontend/lib/stellar.ts
+++ b/frontend/lib/stellar.ts
@@ -530,7 +530,13 @@ async function _fetchTokenInfo(
     decimals,
     totalSupply,
     circulatingSupply,
-    admin: adminVal ? decodeAddress(adminVal) : "N/A",
+    admin:
+      adminVal &&
+      typeof (adminVal as StellarSdk.xdr.ScVal).switch === "function" &&
+      (adminVal as StellarSdk.xdr.ScVal).switch() !==
+        StellarSdk.xdr.ScValType.scvVoid()
+        ? decodeAddress(adminVal as StellarSdk.xdr.ScVal)
+        : "N/A",
     contractId,
     maxSupply,
     contractUri,


### PR DESCRIPTION
Return 'N/A' when admin() is void to avoid decode errors. Fixes #129.

## Summary

Brief description of what this PR does.

**Closes #304 

## Changes

- [ ] Describe change 1
- [ ] Describe change 2

## Type

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] ♻️ Refactor
- [ ] 📝 Documentation
- [ ] 🧪 Tests

## Checklist

- [ ] My code follows the project's style guidelines
- [ ] I've added/updated tests that cover my changes
- [ ] All existing tests pass (`cargo test` / `npm test`)
- [ ] I've updated documentation if needed
- [ ] I've tested on Stellar Testnet (if applicable)

## Screenshots / Recordings

<!-- If UI changes, add screenshots or a screen recording -->
