### PR TITLE
fix(vesting): surface all schedules per recipient in UI (#303) - Vest…

### DIFF
--- a/frontend/app/claim/ClaimVesting.tsx
+++ b/frontend/app/claim/ClaimVesting.tsx
@@ -5,6 +5,7 @@ import { Button } from "@/components/ui/Button";
 import { useToast } from "@/app/providers/ToastProvider";
 import { useWallet } from "@/app/hooks/useWallet";
 import {
+  fetchScheduleCount,
   fetchVestingInfo,
   buildReleaseTx,
   submitTx,
@@ -21,12 +22,14 @@ export function ClaimVesting() {
   const toast = useToast();
 
   const [contractId, setContractId] = useState("");
-  const [info, setInfo] = useState<VestingInfo | null>(null);
+  // One VestingInfo entry per schedule index
+  const [schedules, setSchedules] = useState<VestingInfo[]>([]);
   const [loading, setLoading] = useState(false);
-  const [releasing, setReleasing] = useState(false);
+  // Track which schedule index is currently releasing
+  const [releasingIndex, setReleasingIndex] = useState<number | null>(null);
   const [error, setError] = useState<string | null>(null);
 
-  /* ── Fetch vesting schedule ────────────────────────────────────────── */
+  /* ── Fetch all vesting schedules ───────────────────────────────────── */
   const handleLookup = useCallback(async () => {
     if (!connected || !publicKey) {
       toast.show({
@@ -44,12 +47,24 @@ export function ClaimVesting() {
     }
 
     setError(null);
-    setInfo(null);
+    setSchedules([]);
     setLoading(true);
 
     try {
-      const vestingInfo = await fetchVestingInfo(trimmed, publicKey);
-      setInfo(vestingInfo);
+      const count = await fetchScheduleCount(trimmed, publicKey);
+
+      if (count === 0) {
+        setError("No vesting schedule found for your wallet on this contract.");
+        return;
+      }
+
+      // Fetch all schedules in parallel
+      const infos = await Promise.all(
+        Array.from({ length: count }, (_, i) =>
+          fetchVestingInfo(trimmed, publicKey, i),
+        ),
+      );
+      setSchedules(infos);
     } catch (err: unknown) {
       const msg =
         err instanceof Error ? err.message : "Failed to fetch vesting info";
@@ -61,54 +76,65 @@ export function ClaimVesting() {
     } finally {
       setLoading(false);
     }
-  }, [connected, publicKey, contractId]);
+  }, [connected, publicKey, contractId, toast]);
 
-  /* ── Release unlocked tokens ───────────────────────────────────────── */
-  const handleRelease = useCallback(async () => {
-    if (!connected || !publicKey || !info) return;
+  /* ── Release unlocked tokens for a specific schedule index ─────────── */
+  const handleRelease = useCallback(
+    async (scheduleIndex: number) => {
+      if (!connected || !publicKey) return;
+      const info = schedules[scheduleIndex];
+      if (!info) return;
 
-    if (info.releasableAmount <= 0n) {
-      toast.show({
-        title: "No Tokens Available",
-        message: "No tokens available to release right now.",
-        variant: "error",
-      });
-      return;
-    }
+      if (info.releasableAmount <= 0n) {
+        toast.show({
+          title: "No Tokens Available",
+          message: "No tokens available to release right now.",
+          variant: "error",
+        });
+        return;
+      }
 
-    setReleasing(true);
-    try {
-      const xdr = await buildReleaseTx(contractId.trim(), publicKey, publicKey);
-      const signedXdr = await signTransaction(xdr);
-      await submitTx(signedXdr);
-      toast.show({
-        title: "Success",
-        message: "Tokens released successfully!",
-        variant: "success",
-      });
+      setReleasingIndex(scheduleIndex);
+      try {
+        const xdr = await buildReleaseTx(
+          contractId.trim(),
+          publicKey,
+          publicKey,
+          scheduleIndex,
+        );
+        const signedXdr = await signTransaction(xdr);
+        await submitTx(signedXdr);
+        toast.show({
+          title: "Success",
+          message: `Schedule ${scheduleIndex + 1}: tokens released successfully!`,
+          variant: "success",
+        });
 
-      // Refresh data
-      const updated = await fetchVestingInfo(contractId.trim(), publicKey);
-      setInfo(updated);
-    } catch (err: unknown) {
-      const msg =
-        err instanceof Error ? err.message : "Release transaction failed";
-      toast.show({
-        title: "Release Failed",
-        message: msg,
-        variant: "error",
-      });
-    } finally {
-      setReleasing(false);
-    }
-  }, [connected, publicKey, info, contractId, signTransaction]);
-
-  /* ── Computed display values ───────────────────────────────────────── */
-  const schedule = info?.schedule;
-  const progressPct =
-    schedule && schedule.totalAmount > 0n
-      ? Number((info.vestedAmount * 100n) / schedule.totalAmount)
-      : 0;
+        // Refresh this schedule
+        const updated = await fetchVestingInfo(
+          contractId.trim(),
+          publicKey,
+          scheduleIndex,
+        );
+        setSchedules((prev) => {
+          const next = [...prev];
+          next[scheduleIndex] = updated;
+          return next;
+        });
+      } catch (err: unknown) {
+        const msg =
+          err instanceof Error ? err.message : "Release transaction failed";
+        toast.show({
+          title: "Release Failed",
+          message: msg,
+          variant: "error",
+        });
+      } finally {
+        setReleasingIndex(null);
+      }
+    },
+    [connected, publicKey, schedules, contractId, signTransaction, toast],
+  );
 
   /* ── Render ────────────────────────────────────────────────────────── */
   return (
@@ -117,7 +143,7 @@ export function ClaimVesting() {
       {!connected && (
         <div className="glass-card p-8 text-center">
           <p className="mb-4 text-gray-400">
-            Connect your Freighter wallet to view your vesting schedule.
+            Connect your Freighter wallet to view your vesting schedules.
           </p>
           <Button onClick={connect}>Connect Wallet</Button>
         </div>
@@ -166,106 +192,147 @@ export function ClaimVesting() {
             )}
           </div>
 
-          {/* ── Vesting schedule details ──────────────────────────────── */}
-          {info && schedule && (
-            <div className="glass-card animate-fade-in-up space-y-6 p-6">
-              {/* Header */}
-              <div className="flex items-center justify-between">
-                <h2 className="text-lg font-semibold text-white">
-                  Your Vesting Schedule
-                </h2>
-                {schedule.revoked && (
-                  <span className="rounded-lg bg-red-500/10 px-3 py-1 text-xs font-medium text-red-400">
-                    Revoked
-                  </span>
-                )}
-              </div>
-
-              {/* Progress bar */}
-              <div>
-                <div className="mb-2 flex justify-between text-sm">
-                  <span className="text-gray-400">Vesting Progress</span>
-                  <span className="font-medium text-stellar-400">
-                    {progressPct}%
-                  </span>
-                </div>
-                <div className="h-3 overflow-hidden rounded-full bg-void-700">
-                  <div
-                    className="h-full rounded-full bg-gradient-to-r from-stellar-400 to-stellar-600 transition-all duration-500"
-                    style={{ width: `${Math.min(progressPct, 100)}%` }}
-                    role="progressbar"
-                    aria-valuenow={progressPct}
-                    aria-valuemin={0}
-                    aria-valuemax={100}
-                    aria-label="Vesting progress"
-                  />
-                </div>
-              </div>
-
-              {/* Stats grid */}
-              <div className="grid grid-cols-2 gap-4">
-                <StatCard
-                  label="Total Allocation"
-                  value={formatTokenAmount(schedule.totalAmount)}
-                />
-                <StatCard
-                  label="Vested So Far"
-                  value={formatTokenAmount(info.vestedAmount)}
-                />
-                <StatCard
-                  label="Already Released"
-                  value={formatTokenAmount(schedule.released)}
-                />
-                <StatCard
-                  label="Available to Claim"
-                  value={formatTokenAmount(info.releasableAmount)}
-                  highlight
-                />
-              </div>
-
-              {/* Schedule metadata */}
-              <div className="space-y-2 rounded-xl border border-white/5 bg-void-800/50 p-4 text-sm">
-                <DetailRow
-                  label="Recipient"
-                  value={truncateAddress(schedule.recipient)}
-                />
-                <DetailRow
-                  label="Cliff Ledger"
-                  value={schedule.cliffLedger.toLocaleString()}
-                />
-                <DetailRow
-                  label="End Ledger"
-                  value={schedule.endLedger.toLocaleString()}
-                />
-                <DetailRow
-                  label="Current Ledger"
-                  value={info.currentLedger.toLocaleString()}
-                />
-              </div>
-
-              {/* Release button */}
-              <Button
-                onClick={handleRelease}
-                isLoading={releasing}
-                disabled={
-                  releasing ||
-                  info.releasableAmount <= 0n ||
-                  schedule.revoked
-                }
-                className="w-full"
-                aria-label={`Release ${formatTokenAmount(info.releasableAmount)} vested tokens`}
-              >
-                {schedule.revoked
-                  ? "Schedule Revoked"
-                  : info.releasableAmount <= 0n
-                    ? "No Tokens to Release"
-                    : `Release ${formatTokenAmount(info.releasableAmount)} Tokens`}
-              </Button>
-            </div>
-          )}
+          {/* ── One card per schedule ─────────────────────────────────── */}
+          {schedules.map((info, idx) => (
+            <ScheduleCard
+              key={idx}
+              info={info}
+              scheduleIndex={idx}
+              scheduleCount={schedules.length}
+              releasing={releasingIndex === idx}
+              onRelease={() => handleRelease(idx)}
+            />
+          ))}
         </div>
       )}
     </>
+  );
+}
+
+/* ── Per-schedule card ─────────────────────────────────────────────── */
+
+function ScheduleCard({
+  info,
+  scheduleIndex,
+  scheduleCount,
+  releasing,
+  onRelease,
+}: {
+  info: VestingInfo;
+  scheduleIndex: number;
+  scheduleCount: number;
+  releasing: boolean;
+  onRelease: () => void;
+}) {
+  const { schedule } = info;
+
+  const progressPct =
+    schedule.totalAmount > 0n
+      ? Number((info.vestedAmount * 100n) / schedule.totalAmount)
+      : 0;
+
+  return (
+    <div className="glass-card animate-fade-in-up space-y-6 p-6">
+      {/* Header */}
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-3">
+          <h2 className="text-lg font-semibold text-white">
+            {scheduleCount > 1
+              ? `Vesting Schedule ${scheduleIndex + 1} of ${scheduleCount}`
+              : "Your Vesting Schedule"}
+          </h2>
+          {scheduleCount > 1 && (
+            <span className="rounded-full border border-stellar-400/20 bg-stellar-400/10 px-2.5 py-0.5 text-xs text-stellar-400">
+              #{scheduleIndex + 1}
+            </span>
+          )}
+        </div>
+        {schedule.revoked && (
+          <span className="rounded-lg bg-red-500/10 px-3 py-1 text-xs font-medium text-red-400">
+            Revoked
+          </span>
+        )}
+      </div>
+
+      {/* Progress bar */}
+      <div>
+        <div className="mb-2 flex justify-between text-sm">
+          <span className="text-gray-400">Vesting Progress</span>
+          <span className="font-medium text-stellar-400">
+            {progressPct.toFixed(1)}%
+          </span>
+        </div>
+        <div className="h-3 overflow-hidden rounded-full bg-void-700">
+          <div
+            className="h-full rounded-full bg-gradient-to-r from-stellar-400 to-stellar-600 transition-all duration-500"
+            style={{ width: `${Math.min(progressPct, 100)}%` }}
+            role="progressbar"
+            aria-valuenow={Math.round(progressPct)}
+            aria-valuemin={0}
+            aria-valuemax={100}
+            aria-label={`Vesting progress for schedule ${scheduleIndex + 1}`}
+          />
+        </div>
+      </div>
+
+      {/* Stats grid */}
+      <div className="grid grid-cols-2 gap-4">
+        <StatCard
+          label="Total Allocation"
+          value={formatTokenAmount(schedule.totalAmount)}
+        />
+        <StatCard
+          label="Vested So Far"
+          value={formatTokenAmount(info.vestedAmount)}
+        />
+        <StatCard
+          label="Already Released"
+          value={formatTokenAmount(schedule.released)}
+        />
+        <StatCard
+          label="Available to Claim"
+          value={formatTokenAmount(info.releasableAmount)}
+          highlight
+        />
+      </div>
+
+      {/* Schedule metadata */}
+      <div className="space-y-2 rounded-xl border border-white/5 bg-void-800/50 p-4 text-sm">
+        <DetailRow
+          label="Recipient"
+          value={truncateAddress(schedule.recipient)}
+        />
+        <DetailRow
+          label="Cliff Ledger"
+          value={schedule.cliffLedger.toLocaleString()}
+        />
+        <DetailRow
+          label="End Ledger"
+          value={schedule.endLedger.toLocaleString()}
+        />
+        <DetailRow
+          label="Current Ledger"
+          value={info.currentLedger.toLocaleString()}
+        />
+      </div>
+
+      {/* Release button */}
+      <Button
+        onClick={onRelease}
+        isLoading={releasing}
+        disabled={
+          releasing || info.releasableAmount <= 0n || schedule.revoked
+        }
+        className="w-full"
+        aria-label={`Release ${formatTokenAmount(info.releasableAmount)} vested tokens from schedule ${scheduleIndex + 1}`}
+      >
+        {schedule.revoked
+          ? "Schedule Revoked"
+          : info.releasableAmount <= 0n
+            ? "No Tokens to Release"
+            : `Release ${formatTokenAmount(info.releasableAmount)} Tokens`}
+      </Button>
+    </div>
   );
 }
 

--- a/frontend/app/my-account/PersonalDashboard.tsx
+++ b/frontend/app/my-account/PersonalDashboard.tsx
@@ -42,6 +42,7 @@ export default function PersonalDashboard() {
   const { connected, publicKey, connect, signTransaction } = useWallet();
   const {
     fetchVestingSchedule,
+    fetchVestingScheduleCount,
     fetchCurrentLedger,
     fetchAccountBalances,
     fetchAccountOperations,
@@ -58,8 +59,7 @@ export default function PersonalDashboard() {
 
   // Vesting
   const [vestingContractId, setVestingContractId] = useState("");
-  const [vestingSchedule, setVestingSchedule] =
-    useState<VestingScheduleInfo | null>(null);
+  const [vestingSchedules, setVestingSchedules] = useState<VestingScheduleInfo[]>([]);
   const [vestingLoading, setVestingLoading] = useState(false);
   const [vestingError, setVestingError] = useState<string | null>(null);
   const [currentLedger, setCurrentLedger] = useState(0);
@@ -197,30 +197,42 @@ export default function PersonalDashboard() {
     [publicKey, fetchAccountOperations],
   );
 
-  // Load vesting schedule by contract ID
+  // Load all vesting schedules for the connected wallet from a given contract
   const doVestingLookup = useCallback(async (contractId: string) => {
     if (!publicKey || !contractId.trim()) return;
     setVestingContractId(contractId);
     setVestingLoading(true);
     setVestingError(null);
-    setVestingSchedule(null);
+    setVestingSchedules([]);
     try {
-      const [schedule, ledger] = await Promise.all([
-        fetchVestingSchedule(contractId.trim(), publicKey),
+      const [count, ledger] = await Promise.all([
+        fetchVestingScheduleCount(contractId.trim(), publicKey),
         fetchCurrentLedger(),
       ]);
-      setVestingSchedule(schedule);
+
+      if (count === 0) {
+        setVestingError("No vesting schedule found for your wallet on this contract.");
+        setVestingLoading(false);
+        return;
+      }
+
+      // Fetch all schedules in parallel
+      const schedulePromises = Array.from({ length: count }, (_, i) =>
+        fetchVestingSchedule(contractId.trim(), publicKey, i),
+      );
+      const schedules = await Promise.all(schedulePromises);
+      setVestingSchedules(schedules);
       setCurrentLedger(ledger);
     } catch (err) {
       setVestingError(
         err instanceof Error
           ? err.message
-          : "Failed to fetch vesting schedule. Check the contract ID.",
+          : "Failed to fetch vesting schedules. Check the contract ID.",
       );
     } finally {
       setVestingLoading(false);
     }
-  }, [publicKey, fetchVestingSchedule, fetchCurrentLedger]);
+  }, [publicKey, fetchVestingScheduleCount, fetchVestingSchedule, fetchCurrentLedger]);
 
   const lookupVesting = useCallback(async () => {
     await doVestingLookup(vestingContractId);
@@ -268,7 +280,7 @@ export default function PersonalDashboard() {
         onLookup={lookupVesting}
         loading={vestingLoading}
         error={vestingError}
-        schedule={vestingSchedule}
+        schedules={vestingSchedules}
         currentLedger={currentLedger}
       />
 

--- a/frontend/app/my-account/components/VestingCard.tsx
+++ b/frontend/app/my-account/components/VestingCard.tsx
@@ -54,6 +54,13 @@ export function VestingCard({
             Contract: {truncateAddress(contractId, 6)}
           </span>
           <CopyButton value={contractId} label="Copy contract ID" />
+          {schedule.scheduleCount !== undefined &&
+            schedule.scheduleCount > 1 && (
+              <span className="rounded-full border border-stellar-400/20 bg-stellar-400/10 px-2 py-0.5 text-xs text-stellar-400">
+                Schedule {(schedule.scheduleIndex ?? 0) + 1} of{" "}
+                {schedule.scheduleCount}
+              </span>
+            )}
         </div>
         <span
           className={`rounded-full border px-2.5 py-0.5 text-xs font-medium ${statusColor}`}

--- a/frontend/app/my-account/components/VestingSection.tsx
+++ b/frontend/app/my-account/components/VestingSection.tsx
@@ -10,7 +10,7 @@ export function VestingSection({
   onLookup,
   loading,
   error,
-  schedule,
+  schedules,
   currentLedger,
 }: {
   vestingContractId: string;
@@ -18,13 +18,13 @@ export function VestingSection({
   onLookup: () => void;
   loading: boolean;
   error: string | null;
-  schedule: VestingScheduleInfo | null;
+  schedules: VestingScheduleInfo[];
   currentLedger: number;
 }) {
   return (
-    <section aria-label="Vesting schedule" className="mb-10">
+    <section aria-label="Vesting schedules" className="mb-10">
       <h2 className="mb-4 text-sm font-medium uppercase tracking-wider text-gray-500">
-        Vesting Schedule
+        Vesting Schedules
       </h2>
       <VestingLookup
         vestingContractId={vestingContractId}
@@ -34,13 +34,16 @@ export function VestingSection({
         error={error}
       />
 
-      {schedule && (
-        <div className="mt-4">
-          <VestingCard
-            schedule={schedule}
-            contractId={vestingContractId}
-            currentLedger={currentLedger}
-          />
+      {schedules.length > 0 && (
+        <div className="mt-4 space-y-4">
+          {schedules.map((schedule) => (
+            <VestingCard
+              key={schedule.scheduleIndex ?? 0}
+              schedule={schedule}
+              contractId={vestingContractId}
+              currentLedger={currentLedger}
+            />
+          ))}
         </div>
       )}
     </section>

--- a/frontend/components/forms/VestingForm.tsx
+++ b/frontend/components/forms/VestingForm.tsx
@@ -13,6 +13,11 @@ import { AlertCircle, Clock, Unlock } from "lucide-react";
 const vestingReleaseSchema = z.object({
   vestingContractId: z.string().regex(/^C[A-Z0-9]{55}$/, "Invalid vesting contract ID"),
   recipientAddress: z.string().regex(/^G[A-Z2-7]{55}$/, "Invalid recipient address"),
+  scheduleIndex: z.coerce
+    .number()
+    .int("Must be a whole number")
+    .min(0, "Must be 0 or greater")
+    .optional(),
 });
 
 type VestingReleaseFormData = z.infer<typeof vestingReleaseSchema>;
@@ -58,6 +63,7 @@ export function VestingReleaseForm({ onSuccess }: VestingReleaseFormProps) {
       const result = await simulator.checkVestingRelease(
         formData.vestingContractId,
         formData.recipientAddress,
+        formData.scheduleIndex,
       );
 
       setPreflightResult({
@@ -131,6 +137,22 @@ export function VestingReleaseForm({ onSuccess }: VestingReleaseFormProps) {
         )}
       </div>
 
+      <div>
+        <label className="block text-sm font-medium text-gray-300 mb-2">
+          Schedule Index{" "}
+          <span className="text-gray-500 font-normal">(optional — defaults to latest)</span>
+        </label>
+        <Input
+          type="number"
+          min={0}
+          placeholder="0"
+          {...register("scheduleIndex")}
+        />
+        {errors.scheduleIndex && (
+          <p className="text-red-400 text-sm mt-1">{errors.scheduleIndex.message}</p>
+        )}
+      </div>
+
       {/* Pre-flight check status */}
       {preflightResult && (
         <div className="mt-6">
@@ -173,6 +195,11 @@ export function VestingReleaseForm({ onSuccess }: VestingReleaseFormProps) {
 const vestingRevokeSchema = z.object({
   vestingContractId: z.string().regex(/^C[A-Z0-9]{55}$/, "Invalid vesting contract ID"),
   recipientAddress: z.string().regex(/^G[A-Z2-7]{55}$/, "Invalid recipient address"),
+  scheduleIndex: z.coerce
+    .number()
+    .int("Must be a whole number")
+    .min(0, "Must be 0 or greater")
+    .optional(),
 });
 
 type VestingRevokeFormData = z.infer<typeof vestingRevokeSchema>;
@@ -220,6 +247,7 @@ export function VestingRevokeForm({ adminAddress, onSuccess }: VestingRevokeForm
         formData.vestingContractId,
         formData.recipientAddress,
         adminAddress,
+        formData.scheduleIndex,
       );
 
       setPreflightResult({
@@ -290,6 +318,22 @@ export function VestingRevokeForm({ adminAddress, onSuccess }: VestingRevokeForm
         />
         {errors.recipientAddress && (
           <p className="text-red-400 text-sm mt-1">{errors.recipientAddress.message}</p>
+        )}
+      </div>
+
+      <div>
+        <label className="block text-sm font-medium text-gray-300 mb-2">
+          Schedule Index{" "}
+          <span className="text-gray-500 font-normal">(optional — defaults to latest)</span>
+        </label>
+        <Input
+          type="number"
+          min={0}
+          placeholder="0"
+          {...register("scheduleIndex")}
+        />
+        {errors.scheduleIndex && (
+          <p className="text-red-400 text-sm mt-1">{errors.scheduleIndex.message}</p>
         )}
       </div>
 

--- a/frontend/hooks/useSoroban.ts
+++ b/frontend/hooks/useSoroban.ts
@@ -40,8 +40,14 @@ export function useSoroban() {
   );
 
   const fetchVestingSchedule = useCallback(
+    (vestingContractId: string, recipient: string, scheduleIndex?: number) =>
+      stellar.fetchVestingSchedule(vestingContractId, recipient, networkConfig, scheduleIndex),
+    [networkConfig],
+  );
+
+  const fetchVestingScheduleCount = useCallback(
     (vestingContractId: string, recipient: string) =>
-      stellar.fetchVestingSchedule(vestingContractId, recipient, networkConfig),
+      stellar.fetchVestingScheduleCount(vestingContractId, recipient, networkConfig),
     [networkConfig],
   );
 
@@ -91,6 +97,7 @@ export function useSoroban() {
       fetchTopHolders,
       fetchCurrentLedger,
       fetchVestingSchedule,
+      fetchVestingScheduleCount,
       fetchSupplyBreakdown,
       fetchAccountBalances,
       fetchTransactionHistory,
@@ -109,6 +116,7 @@ export function useSoroban() {
       fetchTopHolders,
       fetchCurrentLedger,
       fetchVestingSchedule,
+      fetchVestingScheduleCount,
       fetchSupplyBreakdown,
       fetchAccountBalances,
       fetchTransactionHistory,

--- a/frontend/hooks/useTransactionSimulator.ts
+++ b/frontend/hooks/useTransactionSimulator.ts
@@ -130,9 +130,10 @@ export function useTransactionSimulator() {
     async checkVestingRelease(
       vestingContractId: string,
       recipientAddress: string,
+      scheduleIndex?: number,
     ): Promise<PreflightCheckResult> {
       return runSimulation(() =>
-        simulateVestingRelease(vestingContractId, recipientAddress, networkConfig),
+        simulateVestingRelease(vestingContractId, recipientAddress, networkConfig, scheduleIndex),
       );
     },
 
@@ -143,6 +144,7 @@ export function useTransactionSimulator() {
       vestingContractId: string,
       recipientAddress: string,
       adminAddress: string,
+      scheduleIndex?: number,
     ): Promise<PreflightCheckResult> {
       return runSimulation(() =>
         simulateVestingRevoke(
@@ -150,6 +152,7 @@ export function useTransactionSimulator() {
           recipientAddress,
           adminAddress,
           networkConfig,
+          scheduleIndex,
         ),
       );
     },


### PR DESCRIPTION
# Closes #303 

## Summary

This PR updates the vesting UI to fully support **multiple vesting schedules per recipient**.

Although the vesting contract has supported indexed schedules since **Wave 5 (#40)**, the frontend always assumed a single schedule (`index = 0`). As a result, recipients with multiple grants (for example, follow-on allocations after a completed vesting period) could only view and claim their first schedule.

The UI now discovers every schedule for a recipient using `get_schedule_count()` and renders each schedule independently, ensuring all vesting grants are visible and claimable.

---

## Problem

The vesting contract stores schedules using `(Address, index)` and exposes:

- `get_schedule_count(recipient)`
- `get_schedule(recipient, index)`
- `release(recipient, index)`
- `revoke(recipient, index)`

The frontend ignored these indexed APIs and always operated on the default schedule (`index = 0`).

This caused several issues:

- Only the first vesting schedule was displayed.
- Additional schedules were invisible in the dashboard.
- Users could not claim tokens from later schedules.
- Admin release/revoke flows could only target the first schedule.

---

## Changes

### ClaimVesting.tsx

- Calls `fetchScheduleCount()` when looking up a recipient.
- Fetches all schedules (`0..count-1`) in parallel.
- Renders one vesting card per schedule.
- Displays an independent progress bar and claimable amount for each schedule.
- Each **Release** button passes the correct `scheduleIndex` to `buildReleaseTx()`.

### PersonalDashboard.tsx

- Replaces:

```ts
vestingSchedule: VestingScheduleInfo | null
```

with:

```ts
vestingSchedules: VestingScheduleInfo[]
```

- Updates the vesting lookup flow to:
  - Fetch the schedule count.
  - Fetch every indexed schedule in parallel.
  - Store all schedules for rendering.

### VestingSection.tsx

- Maps over `vestingSchedules`.
- Renders one `VestingCard` per schedule instead of assuming a single schedule.

### VestingCard.tsx

- Adds a schedule badge when multiple schedules exist.
- Displays labels such as:

```
Schedule 2 of 4
```

to distinguish multiple vesting grants.

### VestingForm.tsx

Adds an optional **Schedule Index** field to both:

- Release form
- Revoke form

This allows administrators to target a specific schedule for a recipient.

### useSoroban.ts

- Exposes `fetchVestingScheduleCount()`.
- Threads `scheduleIndex?: number` through `fetchVestingSchedule()`.

### useTransactionSimulator.ts

- Threads `scheduleIndex?: number` through:
  - `checkVestingRelease()`
  - `checkVestingRevoke()`

The underlying simulator already supported indexed schedules; this change exposes that functionality through the hook.

---

## Result

After these changes:

- ✅ All vesting schedules are discovered automatically.
- ✅ Every schedule is displayed independently.
- ✅ Users can claim tokens from any schedule.
- ✅ Dashboard and lookup views support multiple grants.
- ✅ Admin release and revoke actions can target any indexed schedule.
- ✅ The frontend no longer assumes schedule `0`.

The UI is now fully aligned with the indexed vesting functionality already supported by the smart contract.