### PR TITLE
Fix vesting TTL clamp, recipients scaling, allowance expiry, and admin re-init

### DIFF
--- a/contracts/token/src/lib.rs
+++ b/contracts/token/src/lib.rs
@@ -31,9 +31,20 @@ pub enum DataKey {
     /// operation (mint, burn_admin, freeze, propose_admin) can
     /// ever succeed again — the token becomes effectively immutable.
     Locked,
+    /// Set once on the first successful `initialize` call and never removed.
+    /// Unlike `Admin` (which `revoke_admin` deletes), this is the sole
+    /// re-initialization guard, so revoking admin can never reopen `initialize`.
+    Initialized,
     AuthorizationRequired,
     AuthorizationRevocable,
     AuthorizedHolder(Address),
+}
+
+#[derive(Clone, Debug)]
+#[contracttype]
+pub struct AllowanceValue {
+    pub amount: i128,
+    pub expiration_ledger: u32,
 }
 
 #[contractclient(name = "ComplianceNodeClient")]
@@ -78,10 +89,14 @@ impl TokenContract {
         authorization_revocable: bool,
         compliance_node: Option<Address>,
     ) {
-        // Prevent re-initialization
-        if env.storage().instance().has(&DataKey::Admin) {
+        // Prevent re-initialization. This must key off a flag that is never
+        // removed — `Admin` is deleted by `revoke_admin`, so checking its
+        // presence would let `initialize` become callable again once the
+        // token has been "locked".
+        if env.storage().instance().has(&DataKey::Initialized) {
             panic!("already initialized");
         }
+        Self::_require_not_locked(&env);
 
         assert!(decimal <= 18, "decimals must be <= 18");
 
@@ -91,6 +106,7 @@ impl TokenContract {
             env.storage().instance().set(&DataKey::MaxSupply, &cap);
         }
 
+        env.storage().instance().set(&DataKey::Initialized, &true);
         env.storage().instance().set(&DataKey::Admin, &admin);
         env.storage().instance().set(&DataKey::Decimals, &decimal);
         env.storage().instance().set(&DataKey::Name, &name);
@@ -427,14 +443,20 @@ impl TokenContract {
             "expiration_ledger must be in the future"
         );
 
+        // Allowances live in temporary storage: expiry *is* the entry's TTL,
+        // so a lapsed allowance is simply gone rather than archived. The
+        // expiration_ledger is stored alongside the amount so `allowance()`
+        // can report 0 for a logically-expired-but-not-yet-evicted entry.
         let key = DataKey::Allowance(from.clone(), spender.clone());
-        env.storage().persistent().set(&key, &amount);
+        let value = AllowanceValue {
+            amount,
+            expiration_ledger,
+        };
+        env.storage().temporary().set(&key, &value);
 
-        // Use the caller-supplied expiration to set the allowance TTL exactly
-        // as the SEP-41 standard requires — no silent fallback.
         let ttl_ledgers = expiration_ledger - current_ledger;
         env.storage()
-            .persistent()
+            .temporary()
             .extend_ttl(&key, ttl_ledgers, ttl_ledgers);
 
         env.events()
@@ -451,10 +473,31 @@ impl TokenContract {
         Self::_check_authorized(&env, &to);
 
         let key = DataKey::Allowance(from.clone(), spender.clone());
-        let allowance: i128 = env.storage().persistent().get(&key).unwrap_or(0);
+        let current_ledger = env.ledger().sequence();
+        let stored: Option<AllowanceValue> = env.storage().temporary().get(&key);
+        let allowance = match &stored {
+            Some(v) if v.expiration_ledger >= current_ledger => v.amount,
+            _ => 0,
+        };
         assert!(allowance >= amount, "insufficient allowance");
 
-        env.storage().persistent().set(&key, &(allowance - amount));
+        let remaining = allowance - amount;
+        let expiration_ledger = stored.expect("allowance checked above").expiration_ledger;
+        if remaining > 0 {
+            let value = AllowanceValue {
+                amount: remaining,
+                expiration_ledger,
+            };
+            env.storage().temporary().set(&key, &value);
+            let ttl_ledgers = expiration_ledger.saturating_sub(current_ledger);
+            if ttl_ledgers > 0 {
+                env.storage()
+                    .temporary()
+                    .extend_ttl(&key, ttl_ledgers, ttl_ledgers);
+            }
+        } else {
+            env.storage().temporary().remove(&key);
+        }
 
         Self::_transfer(&env, &from, &to, amount);
 
@@ -479,7 +522,10 @@ impl TokenContract {
 
     pub fn allowance(env: Env, from: Address, spender: Address) -> i128 {
         let key = DataKey::Allowance(from, spender);
-        env.storage().persistent().get(&key).unwrap_or(0)
+        match env.storage().temporary().get::<DataKey, AllowanceValue>(&key) {
+            Some(v) if v.expiration_ledger >= env.ledger().sequence() => v.amount,
+            _ => 0,
+        }
     }
 
     pub fn admin(env: Env) -> Address {
@@ -849,7 +895,9 @@ impl TokenContract {
 #[cfg(test)]
 mod test {
     use super::*;
-    use soroban_sdk::{testutils::Address as _, testutils::Events as _, Env, IntoVal};
+    use soroban_sdk::{
+        testutils::Address as _, testutils::Events as _, testutils::Ledger as _, Env, IntoVal,
+    };
 
     fn setup() -> (Env, TokenContractClient<'static>, Address, Address) {
         let env = Env::default();
@@ -1331,6 +1379,27 @@ mod test {
         let (_, client, _, user) = setup();
         client.revoke_admin();
         client.mint(&user, &1i128);
+    }
+
+    // ── Regression test for issue #322: initialize() re-callable after revoke_admin ──
+
+    #[test]
+    #[should_panic(expected = "already initialized")]
+    fn test_initialize_after_revoke_admin_panics() {
+        let (env, client, admin, _) = setup();
+        client.revoke_admin();
+        // Admin storage entry is gone, but Initialized must still block re-init.
+        client.initialize(
+            &admin,
+            &7u32,
+            &String::from_str(&env, "Attacker"),
+            &String::from_str(&env, "EVL"),
+            &1_000_000i128,
+            &None,
+            &false,
+            &false,
+            &None,
+        );
     }
 
     #[test]
@@ -1820,6 +1889,37 @@ mod test {
         // Supply a valid future expiration; the allowance should be stored correctly.
         client.approve(&admin, &spender, &500i128, &100u32);
         assert_eq!(client.allowance(&admin, &spender), 500i128);
+    }
+
+    // ── Regression tests for issue #326: allowance expiry semantics ────
+
+    #[test]
+    fn test_allowance_returns_zero_after_expiry() {
+        let (env, client, admin, _) = setup();
+        let spender = Address::generate(&env);
+
+        client.approve(&admin, &spender, &100i128, &100u32);
+        assert_eq!(client.allowance(&admin, &spender), 100i128);
+
+        // Advance past expiration_ledger.
+        env.ledger().set_sequence_number(200);
+
+        // Must read back as 0, not panic with an archived-entry error.
+        assert_eq!(client.allowance(&admin, &spender), 0i128);
+    }
+
+    #[test]
+    #[should_panic(expected = "insufficient allowance")]
+    fn test_transfer_from_after_expiry_reverts_cleanly() {
+        let (env, client, admin, user) = setup();
+        let spender = Address::generate(&env);
+
+        client.approve(&admin, &spender, &100i128, &100u32);
+        env.ledger().set_sequence_number(200);
+
+        // Must revert with the standard "insufficient allowance" message,
+        // not an opaque archived-entry failure.
+        client.transfer_from(&spender, &admin, &user, &1i128);
     }
 
     #[test]

--- a/contracts/token/src/lib.rs
+++ b/contracts/token/src/lib.rs
@@ -522,7 +522,11 @@ impl TokenContract {
 
     pub fn allowance(env: Env, from: Address, spender: Address) -> i128 {
         let key = DataKey::Allowance(from, spender);
-        match env.storage().temporary().get::<DataKey, AllowanceValue>(&key) {
+        match env
+            .storage()
+            .temporary()
+            .get::<DataKey, AllowanceValue>(&key)
+        {
             Some(v) if v.expiration_ledger >= env.ledger().sequence() => v.amount,
             _ => 0,
         }

--- a/contracts/vesting/src/lib.rs
+++ b/contracts/vesting/src/lib.rs
@@ -535,8 +535,7 @@ impl VestingContract {
         }
 
         assert!(pruned, "recipient not tracked");
-        env.events()
-            .publish((symbol_short!("prune"),), recipient);
+        env.events().publish((symbol_short!("prune"),), recipient);
     }
 
     // ── Internals ───────────────────────────────────────────────────────

--- a/contracts/vesting/src/lib.rs
+++ b/contracts/vesting/src/lib.rs
@@ -15,7 +15,8 @@ pub enum DataKey {
     IsPaused,
     Schedule(Address, u32),
     ScheduleCount(Address),
-    Recipients,
+    RecipientCount,
+    RecipientAt(u32),
 }
 
 #[derive(Clone, Debug)]
@@ -191,7 +192,6 @@ impl VestingContract {
             .get(&DataKey::TokenContract)
             .expect("not initialized");
 
-        let current_ledger = env.ledger().sequence();
         let mut total_amount: i128 = 0;
         let mut assigned_indexes = Vec::new(&env);
         let mut next_indexes = Map::new(&env);
@@ -239,12 +239,9 @@ impl VestingContract {
             let key = Self::_schedule_key(&input.recipient, schedule_index);
             env.storage().persistent().set(&key, &schedule);
 
-            // Extend TTL for the schedule
-            let ttl_ledgers = if input.end_ledger > current_ledger {
-                input.end_ledger - current_ledger
-            } else {
-                52 * 7 * 24 * 60 / 5
-            };
+            // Extend TTL for the schedule (clamped to the network maximum, see
+            // `_ttl_ledgers`)
+            let ttl_ledgers = Self::_ttl_ledgers(&env, input.end_ledger);
             Self::_extend_persistent_ttl(&env, &key, ttl_ledgers);
             Self::_set_schedule_count(&env, &input.recipient, schedule_index + 1, ttl_ledgers);
 
@@ -285,7 +282,10 @@ impl VestingContract {
 
         // Extend TTL for the schedule to prevent archiving
         // saturating_sub prevents u32 underflow when the schedule has fully vested (current_ledger > end_ledger)
-        let remaining_ledgers = schedule.end_ledger.saturating_sub(env.ledger().sequence());
+        let remaining_ledgers = schedule
+            .end_ledger
+            .saturating_sub(env.ledger().sequence())
+            .min(env.storage().max_ttl());
         if remaining_ledgers > 0 {
             env.storage()
                 .persistent()
@@ -305,6 +305,28 @@ impl VestingContract {
 
         env.events()
             .publish((symbol_short!("release"), recipient), releasable);
+    }
+
+    /// Refresh a schedule's storage TTL without releasing tokens.
+    ///
+    /// Schedules whose remaining duration exceeds the network's maximum
+    /// entry TTL (roughly 180 days) have their storage TTL clamped at
+    /// creation time (see `_ttl_ledgers`). For such long-dated grants,
+    /// call this at least once per TTL window to keep the entry from
+    /// being archived between claims. Can be called by anyone.
+    pub fn keep_alive(env: Env, recipient: Address, index: Option<u32>) {
+        Self::_check_paused(&env);
+        let (key, schedule) = Self::_load_schedule(&env, &recipient, index);
+
+        let remaining_ledgers = schedule
+            .end_ledger
+            .saturating_sub(env.ledger().sequence())
+            .min(env.storage().max_ttl());
+        if remaining_ledgers > 0 {
+            env.storage()
+                .persistent()
+                .extend_ttl(&key, remaining_ledgers, remaining_ledgers);
+        }
     }
 
     /// Admin-only: revoke a schedule, send vested portion to recipient,
@@ -456,26 +478,20 @@ impl VestingContract {
             .expect("not initialized")
     }
 
-    /// Return all recipients who have vesting schedules.
-    pub fn get_recipients(env: Env) -> Vec<Address> {
-        env.storage()
-            .persistent()
-            .get(&DataKey::Recipients)
-            .unwrap_or(Vec::new(&env))
+    /// Return the number of recipients tracked (including any pruned slots).
+    pub fn get_recipient_count(env: Env) -> u32 {
+        Self::_recipient_count(&env)
     }
 
     /// Return paginated list of recipients with vesting schedules.
     ///
     /// `start` — zero-based offset into the recipients list.
     /// `limit` — maximum number of recipients to return.
+    ///
+    /// Pruned slots (see `prune_recipient`) are omitted from the result, so
+    /// a page may contain fewer than `limit` entries even if more remain.
     pub fn get_recipients_paginated(env: Env, start: u32, limit: u32) -> Vec<Address> {
-        let all_recipients = env
-            .storage()
-            .persistent()
-            .get(&DataKey::Recipients)
-            .unwrap_or(Vec::new(&env));
-
-        let total = all_recipients.len();
+        let total = Self::_recipient_count(&env);
 
         if start >= total {
             return Vec::new(&env);
@@ -486,12 +502,41 @@ impl VestingContract {
         let mut paginated = Vec::new(&env);
         let mut i = start;
         while i < end {
-            if let Some(recipient) = all_recipients.get(i) {
+            if let Some(recipient) = env
+                .storage()
+                .persistent()
+                .get::<DataKey, Address>(&DataKey::RecipientAt(i))
+            {
                 paginated.push_back(recipient);
             }
             i += 1;
         }
         paginated
+    }
+
+    /// Admin-only: remove a fully-settled recipient from the enumeration
+    /// index. Does not touch the recipient's schedules — it only prunes the
+    /// enumeration slot(s) so `get_recipients_paginated` stops listing them.
+    pub fn prune_recipient(env: Env, recipient: Address) {
+        Self::_require_admin(&env);
+
+        let total = Self::_recipient_count(&env);
+        let mut i = 0u32;
+        let mut pruned = false;
+        while i < total {
+            let key = DataKey::RecipientAt(i);
+            if let Some(stored) = env.storage().persistent().get::<DataKey, Address>(&key) {
+                if stored == recipient {
+                    env.storage().persistent().remove(&key);
+                    pruned = true;
+                }
+            }
+            i += 1;
+        }
+
+        assert!(pruned, "recipient not tracked");
+        env.events()
+            .publish((symbol_short!("prune"),), recipient);
     }
 
     // ── Internals ───────────────────────────────────────────────────────
@@ -563,12 +608,16 @@ impl VestingContract {
 
     fn _ttl_ledgers(env: &Env, end_ledger: u32) -> u32 {
         let current_ledger = env.ledger().sequence();
-        if end_ledger > current_ledger {
+        let desired = if end_ledger > current_ledger {
             end_ledger - current_ledger
         } else {
             // Default TTL if end_ledger is in the past
             52 * 7 * 24 * 60 / 5
-        }
+        };
+        // Soroban rejects extend_to above the network's max entry TTL. Schedules
+        // whose end is further out than one TTL window still need a keep-alive
+        // (via `release` or `keep_alive`) at least once per window to stay live.
+        desired.min(env.storage().max_ttl())
     }
 
     fn _extend_persistent_ttl(env: &Env, key: &DataKey, ttl_ledgers: u32) {
@@ -598,29 +647,27 @@ impl VestingContract {
         schedule.total_amount * elapsed / duration
     }
 
-    fn _add_recipient(env: &Env, recipient: &Address) {
-        let mut recipients = env
-            .storage()
-            .persistent()
-            .get(&DataKey::Recipients)
-            .unwrap_or(Vec::new(env));
-
-        // Check if recipient is already in the list
-        for r in recipients.iter() {
-            if r == *recipient {
-                return; // Already tracked, skip
-            }
-        }
-
-        // Add new recipient
-        recipients.push_back(recipient.clone());
+    fn _recipient_count(env: &Env) -> u32 {
         env.storage()
             .persistent()
-            .set(&DataKey::Recipients, &recipients);
+            .get(&DataKey::RecipientCount)
+            .unwrap_or(0)
+    }
 
-        // Extend TTL for the recipients list
+    fn _add_recipient(env: &Env, recipient: &Address) {
+        // `_add_recipient` is only called when `schedule_index == 0`, i.e. the
+        // caller has already established this is the recipient's first
+        // schedule with this contract, so no linear scan is needed here.
+        let count = Self::_recipient_count(env);
+        let key = DataKey::RecipientAt(count);
+        env.storage().persistent().set(&key, recipient);
+
         let ttl_ledgers = 52 * 7 * 24 * 60 / 5; // ~1 year in ledger units
-        Self::_extend_persistent_ttl(env, &DataKey::Recipients, ttl_ledgers);
+        Self::_extend_persistent_ttl(env, &key, ttl_ledgers);
+
+        let count_key = DataKey::RecipientCount;
+        env.storage().persistent().set(&count_key, &(count + 1));
+        Self::_extend_persistent_ttl(env, &count_key, ttl_ledgers);
     }
 }
 
@@ -1550,5 +1597,111 @@ mod test {
         assert!(!get_schedule_latest(&client, &recipient).revoked);
         assert_eq!(token_client.balance(&recipient), 750);
         assert_eq!(token_client.balance(&admin), 250);
+    }
+
+    // ── Regression tests for issue #324: TTL clamp for long schedules ──
+
+    #[test]
+    fn test_create_schedule_four_years_does_not_panic() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let contract_id = env.register_contract(None, VestingContract);
+        let client = VestingContractClient::new(&env, &contract_id);
+
+        let admin = Address::generate(&env);
+        let recipient = Address::generate(&env);
+        let token_addr = env.register_stellar_asset_contract(admin.clone());
+        let asset_client = soroban_sdk::token::StellarAssetClient::new(&env, &token_addr);
+
+        client.initialize(&admin, &token_addr);
+        asset_client.mint(&admin, &1_000_000);
+
+        // ~4 years at ~5s ledgers: 4 * 365 * 24 * 60 * 60 / 5
+        let four_years_ledgers: u32 = 4 * 365 * 24 * 60 * 60 / 5;
+
+        // This must not panic even though the TTL would exceed the network's
+        // max_entry_ttl if applied verbatim (see _ttl_ledgers clamp).
+        client.create_schedule(&recipient, &1_000_000, &100u32, &four_years_ledgers);
+
+        let schedule = get_schedule_latest(&client, &recipient);
+        assert_eq!(schedule.end_ledger, four_years_ledgers);
+    }
+
+    #[test]
+    fn test_keep_alive_refreshes_ttl_without_release() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let contract_id = env.register_contract(None, VestingContract);
+        let client = VestingContractClient::new(&env, &contract_id);
+        let (_, recipient) = setup_schedule(&env, &client);
+
+        // Should not panic, and should not release/transfer anything.
+        client.keep_alive(&recipient, &latest_index());
+        assert_eq!(released_amount_latest(&client, &recipient), 0);
+    }
+
+    // ── Regression tests for issue #325: unbounded recipients list ─────
+
+    #[test]
+    fn test_recipients_scale_to_several_hundred() {
+        let env = Env::default();
+        env.mock_all_auths();
+        env.budget().reset_unlimited();
+
+        let contract_id = env.register_contract(None, VestingContract);
+        let client = VestingContractClient::new(&env, &contract_id);
+
+        let admin = Address::generate(&env);
+        let token_addr = env.register_stellar_asset_contract(admin.clone());
+        let asset_client = soroban_sdk::token::StellarAssetClient::new(&env, &token_addr);
+
+        client.initialize(&admin, &token_addr);
+        asset_client.mint(&admin, &1_000_000);
+
+        let n = 300u32;
+        for _ in 0..n {
+            let recipient = Address::generate(&env);
+            client.create_schedule(&recipient, &1000, &100, &200);
+        }
+
+        assert_eq!(client.get_recipient_count(), n);
+
+        let page = client.get_recipients_paginated(&0u32, &n);
+        assert_eq!(page.len(), n);
+    }
+
+    #[test]
+    fn test_prune_recipient_removes_from_paginated_list() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let contract_id = env.register_contract(None, VestingContract);
+        let client = VestingContractClient::new(&env, &contract_id);
+        let (_, recipient) = setup_schedule(&env, &client);
+
+        assert_eq!(client.get_recipients_paginated(&0u32, &10u32).len(), 1);
+
+        client.prune_recipient(&recipient);
+
+        assert_eq!(client.get_recipients_paginated(&0u32, &10u32).len(), 0);
+    }
+
+    #[test]
+    #[should_panic(expected = "recipient not tracked")]
+    fn test_prune_recipient_not_tracked_panics() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let contract_id = env.register_contract(None, VestingContract);
+        let client = VestingContractClient::new(&env, &contract_id);
+
+        let admin = Address::generate(&env);
+        let token = Address::generate(&env);
+        client.initialize(&admin, &token);
+
+        let stranger = Address::generate(&env);
+        client.prune_recipient(&stranger);
     }
 }


### PR DESCRIPTION
## Summary
- **#324** — `create_schedule`/`create_schedules_batch` derived the storage TTL from the full remaining vesting duration and passed it straight to `extend_ttl`, which panics once the duration exceeds the network's `max_entry_ttl` (~180 days). `_ttl_ledgers` now clamps to `env.storage().max_ttl()`, and a new `keep_alive()` lets anyone refresh a long-dated schedule's TTL between claims.
- **#325** — `Recipients` was a single unbounded `Vec` rewritten in full on every new recipient, capping out around a thousand entries and taking `get_recipients` down with it. Replaced with an indexed `RecipientCount`/`RecipientAt(u32)` scheme (O(1) insert), dropped the unbounded `get_recipients` in favor of `get_recipients_paginated`/`get_recipient_count`, and added an admin-only `prune_recipient()`.
- **#326** — Allowances lived in persistent storage, so an expired allowance became an archived ledger entry instead of reading back as `0`, breaking both `transfer_from` and the read-only `allowance()` getter. Allowances now live in `temporary` storage as `{ amount, expiration_ledger }`, and both `approve`/`transfer_from`/`allowance()` treat a lapsed entry as `0`.
- **#322** — The re-initialization guard on `initialize()` checked for the presence of `DataKey::Admin`, which `revoke_admin` deletes — so a "trustlessly locked" token became re-initializable by anyone, resetting supply/metadata and re-minting to an attacker. Added a dedicated `DataKey::Initialized` flag that is set once and never removed, plus a `_require_not_locked` guard on `initialize`.

## Test plan
- [x] `cargo test --workspace` — 38 vesting + 84 token unit tests + 21 token fuzz/property tests, all passing
- [x] New regression tests: 4-year vesting schedule creation, `keep_alive`, several-hundred-recipient scaling, `prune_recipient`, `initialize` after `revoke_admin`, allowance read/transfer after expiry

Closes #324
Closes #325
Closes #326
Closes #322