### PR TITLE
Add token-state banner to public token page and dashboard header

### DIFF
--- a/frontend/app/claim/ClaimVesting.tsx
+++ b/frontend/app/claim/ClaimVesting.tsx
@@ -321,17 +321,28 @@ function ScheduleCard({
         onClick={onRelease}
         isLoading={releasing}
         disabled={
-          releasing || info.releasableAmount <= 0n || schedule.revoked
+          releasing ||
+          info.releasableAmount <= 0n ||
+          schedule.revoked ||
+          info.isPaused
         }
         className="w-full"
         aria-label={`Release ${formatTokenAmount(info.releasableAmount)} vested tokens from schedule ${scheduleIndex + 1}`}
       >
         {schedule.revoked
           ? "Schedule Revoked"
-          : info.releasableAmount <= 0n
-            ? "No Tokens to Release"
-            : `Release ${formatTokenAmount(info.releasableAmount)} Tokens`}
+          : info.isPaused
+            ? "Vesting Paused"
+            : info.releasableAmount <= 0n
+              ? "No Tokens to Release"
+              : `Release ${formatTokenAmount(info.releasableAmount)} Tokens`}
       </Button>
+      {info.isPaused && !schedule.revoked && (
+        <p className="text-xs text-orange-400">
+          This vesting contract is currently paused by its admin. Releases
+          are halted until it is unpaused.
+        </p>
+      )}
     </div>
   );
 }

--- a/frontend/app/dashboard/[contractId]/TokenDashboard.tsx
+++ b/frontend/app/dashboard/[contractId]/TokenDashboard.tsx
@@ -5,11 +5,14 @@ import { useTranslations } from "next-intl";
 import { Download } from "lucide-react";
 import {
   truncateAddress,
+  fetchWalletTokenState,
   type TokenInfo,
   type TokenHolder,
   type SupplyBreakdown,
+  type WalletTokenState,
 } from "@/lib/stellar";
 import { useSoroban } from "@/hooks/useSoroban";
+import { TokenStatusBanner } from "@/components/TokenStatusBanner";
 import VestingProgress from "./VestingProgress";
 import TransactionHistory from "./TransactionHistory";
 import SupplyBreakdownChart from "@/components/charts/SupplyBreakdownChart";
@@ -19,6 +22,7 @@ import { TransferPanel } from "./components/TransferPanel";
 import { UserPanel } from "./components/UserPanel";
 import { AdminPanel } from "./components/AdminPanel";
 import { useWallet } from "@/app/hooks/useWallet";
+import { useNetwork } from "@/app/providers/NetworkProvider";
 import { HoldersTable, exportHoldersCsv } from "./components/HoldersTable";
 import { InfoCard } from "./components/InfoCard";
 import {
@@ -37,9 +41,13 @@ export default function TokenDashboard({ contractId }: { contractId: string }) {
   const [holders, setHolders] = useState<TokenHolder[]>([]);
   const [supplyBreakdown, setSupplyBreakdown] =
     useState<SupplyBreakdown | null>(null);
+  const [walletState, setWalletState] = useState<WalletTokenState | null>(
+    null,
+  );
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
-  const { publicKey } = useWallet();
+  const { publicKey, connected } = useWallet();
+  const { networkConfig } = useNetwork();
   const { fetchTokenInfo, fetchTopHolders, fetchSupplyBreakdown } =
     useSoroban();
 
@@ -78,6 +86,24 @@ export default function TokenDashboard({ contractId }: { contractId: string }) {
     loadData();
   }, [loadData]);
 
+  useEffect(() => {
+    if (!connected || !publicKey) {
+      setWalletState(null);
+      return;
+    }
+    let cancelled = false;
+    fetchWalletTokenState(contractId, publicKey, networkConfig)
+      .then((state) => {
+        if (!cancelled) setWalletState(state);
+      })
+      .catch(() => {
+        if (!cancelled) setWalletState(null);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [contractId, publicKey, connected, networkConfig]);
+
   const isInvalidToken = error?.startsWith("Invalid token contract:") ?? false;
 
   if (loading) return <LoadingState />;
@@ -106,6 +132,8 @@ export default function TokenDashboard({ contractId }: { contractId: string }) {
           />
         </div>
       </div>
+
+      <TokenStatusBanner tokenInfo={tokenInfo} walletState={walletState} />
 
       {/* Token info grid */}
       <section aria-label={t("sections.tokenDetails")} className="mb-10">
@@ -252,6 +280,8 @@ export default function TokenDashboard({ contractId }: { contractId: string }) {
         contractId={contractId}
         tokenSymbol={tokenInfo.symbol}
         tokenDecimals={tokenInfo.decimals}
+        tokenInfo={tokenInfo}
+        walletState={walletState}
       />
     </div>
   );

--- a/frontend/app/dashboard/[contractId]/components/TransferPanel.tsx
+++ b/frontend/app/dashboard/[contractId]/components/TransferPanel.tsx
@@ -22,6 +22,8 @@ import {
   xdr,
   Address,
 } from "@stellar/stellar-sdk";
+import { getTokenActionBlockedReason } from "@/components/TokenStatusBanner";
+import type { TokenInfo, WalletTokenState } from "@/lib/stellar";
 
 /* ── Validation Schema ────────────────────────────────────────── */
 
@@ -72,13 +74,20 @@ interface TransferPanelProps {
   contractId: string;
   tokenSymbol: string;
   tokenDecimals: number;
+  tokenInfo?: Pick<TokenInfo, "isPaused">;
+  walletState?: WalletTokenState | null;
 }
 
 export function TransferPanel({
   contractId,
   tokenSymbol,
   tokenDecimals,
+  tokenInfo,
+  walletState,
 }: TransferPanelProps) {
+  const blockedReason = tokenInfo
+    ? getTokenActionBlockedReason(tokenInfo, walletState)
+    : null;
   const { signTransaction, publicKey, connected } = useWallet();
   const { networkConfig } = useNetwork();
 
@@ -163,6 +172,11 @@ export function TransferPanel({
   const handleTransfer = async (data: TransferData) => {
     if (!publicKey || !connected) {
       setError("Please connect your wallet first");
+      return;
+    }
+
+    if (blockedReason) {
+      setError(blockedReason);
       return;
     }
 
@@ -379,6 +393,13 @@ export function TransferPanel({
             disabled={loading}
           />
 
+          {blockedReason && !error && (
+            <div className="flex items-start gap-2 p-3 bg-orange-500/10 border border-orange-500/20 rounded-lg">
+              <AlertCircle className="h-4 w-4 text-orange-400 mt-0.5 shrink-0" />
+              <p className="text-sm text-orange-300">{blockedReason}</p>
+            </div>
+          )}
+
           {error && (
             <div className="flex items-start gap-2 p-3 bg-red-500/10 border border-red-500/20 rounded-lg">
               <AlertCircle className="h-4 w-4 text-red-400 mt-0.5 shrink-0" />
@@ -399,7 +420,7 @@ export function TransferPanel({
             type="submit"
             className="w-full mt-4 shadow-lg shadow-stellar-500/20"
             isLoading={loading}
-            disabled={loading || checkingBalance}
+            disabled={loading || checkingBalance || !!blockedReason}
           >
             {success ? (
               <span className="flex items-center gap-2">

--- a/frontend/app/token/[contractId]/PublicTokenPage.tsx
+++ b/frontend/app/token/[contractId]/PublicTokenPage.tsx
@@ -12,11 +12,15 @@ import {
 } from "lucide-react";
 import {
   truncateAddress,
+  fetchWalletTokenState,
   type TokenInfo,
   type TokenHolder,
+  type WalletTokenState,
 } from "@/lib/stellar";
 import { useSoroban } from "@/hooks/useSoroban";
 import { useNetwork } from "@/app/providers/NetworkProvider";
+import { useWallet } from "@/app/hooks/useWallet";
+import { TokenStatusBanner } from "@/components/TokenStatusBanner";
 import InvalidTokenContract from "../../components/InvalidTokenContract";
 
 // ---------------------------------------------------------------------------
@@ -320,8 +324,10 @@ export default function PublicTokenPage({
 }) {
   const { fetchTokenInfo, fetchTopHolders, validateTokenContract } = useSoroban();
   const { networkConfig } = useNetwork();
+  const { publicKey, connected } = useWallet();
   const [tokenInfo, setTokenInfo] = useState<TokenInfo | null>(null);
   const [holders, setHolders] = useState<TokenHolder[]>([]);
+  const [walletState, setWalletState] = useState<WalletTokenState | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [isValidToken, setIsValidToken] = useState<boolean | null>(null);
@@ -372,6 +378,24 @@ export default function PublicTokenPage({
     loadData();
   }, [loadData]);
 
+  useEffect(() => {
+    if (!connected || !publicKey) {
+      setWalletState(null);
+      return;
+    }
+    let cancelled = false;
+    fetchWalletTokenState(contractId, publicKey, networkConfig)
+      .then((state) => {
+        if (!cancelled) setWalletState(state);
+      })
+      .catch(() => {
+        if (!cancelled) setWalletState(null);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [contractId, publicKey, connected, networkConfig]);
+
   if (loading) return <LoadingState />;
   
   // Show invalid token component if validation failed
@@ -414,6 +438,8 @@ export default function PublicTokenPage({
           <ShareButton contractId={contractId} tokenInfo={tokenInfo} />
         </div>
       </div>
+
+      <TokenStatusBanner tokenInfo={tokenInfo} walletState={walletState} />
 
       {/* Token info grid */}
       <section aria-label="Token details" className="mb-10">

--- a/frontend/components/TokenStatusBanner.tsx
+++ b/frontend/components/TokenStatusBanner.tsx
@@ -1,0 +1,132 @@
+"use client";
+
+import type React from "react";
+import { PauseCircle, ShieldCheck, ShieldAlert, Lock, SnowflakeIcon } from "lucide-react";
+import { Alert, AlertTitle, AlertDescription } from "@/components/ui/Alert";
+import type { TokenInfo, WalletTokenState } from "@/lib/stellar";
+
+interface TokenStatusBannerProps {
+  tokenInfo: Pick<TokenInfo, "isPaused" | "isLocked" | "authorizationRequired">;
+  /** Wallet-specific state, when a wallet is connected. */
+  walletState?: WalletTokenState | null;
+}
+
+/**
+ * Reason a transfer/claim CTA should be disabled for the current token +
+ * wallet state, or null if nothing blocks the action.
+ */
+export function getTokenActionBlockedReason(
+  tokenInfo: Pick<TokenInfo, "isPaused">,
+  walletState?: WalletTokenState | null,
+): string | null {
+  if (tokenInfo.isPaused) {
+    return "This token is currently paused by its admin — transfers are halted.";
+  }
+  if (walletState?.isFrozen) {
+    return "Your wallet is frozen for this token and cannot send or receive it.";
+  }
+  if (walletState && !walletState.isAuthorized) {
+    return "Your wallet is not authorized to hold or transfer this token.";
+  }
+  return null;
+}
+
+/**
+ * Live status banner surfacing token pause/lock/authorization state, plus
+ * the connected wallet's authorization/freeze state when available.
+ */
+export function TokenStatusBanner({
+  tokenInfo,
+  walletState,
+}: TokenStatusBannerProps) {
+  const banners: React.ReactElement[] = [];
+
+  if (tokenInfo.isPaused) {
+    banners.push(
+      <Alert key="paused" variant="warning">
+        <div className="flex items-start gap-3">
+          <PauseCircle className="mt-0.5 h-5 w-5 shrink-0" />
+          <div>
+            <AlertTitle>Token is paused</AlertTitle>
+            <AlertDescription>
+              The admin has paused this token. Transfers and other
+              state-changing operations are halted until it is unpaused.
+            </AlertDescription>
+          </div>
+        </div>
+      </Alert>,
+    );
+  }
+
+  if (walletState?.isFrozen) {
+    banners.push(
+      <Alert key="frozen" variant="destructive">
+        <div className="flex items-start gap-3">
+          <SnowflakeIcon className="mt-0.5 h-5 w-5 shrink-0" />
+          <div>
+            <AlertTitle>Your wallet is frozen</AlertTitle>
+            <AlertDescription>
+              This wallet has been frozen by the token admin and cannot send
+              or receive this token.
+            </AlertDescription>
+          </div>
+        </div>
+      </Alert>,
+    );
+  } else if (walletState && !walletState.isAuthorized) {
+    banners.push(
+      <Alert key="unauthorized" variant="destructive">
+        <div className="flex items-start gap-3">
+          <ShieldAlert className="mt-0.5 h-5 w-5 shrink-0" />
+          <div>
+            <AlertTitle>Your wallet is not authorized</AlertTitle>
+            <AlertDescription>
+              This token requires authorization, and this wallet does not
+              currently have it. Contact the token admin to request
+              authorization.
+            </AlertDescription>
+          </div>
+        </div>
+      </Alert>,
+    );
+  }
+
+  if (tokenInfo.authorizationRequired) {
+    banners.push(
+      <Alert key="auth-required" variant="default">
+        <div className="flex items-start gap-3">
+          <ShieldCheck className="mt-0.5 h-5 w-5 shrink-0" />
+          <div>
+            <AlertTitle>Authorization required</AlertTitle>
+            <AlertDescription>
+              Holders must be authorized by the token admin before they can
+              transact with this token.
+            </AlertDescription>
+          </div>
+        </div>
+      </Alert>,
+    );
+  }
+
+  if (tokenInfo.isLocked) {
+    banners.push(
+      <Alert key="locked" variant="success">
+        <div className="flex items-start gap-3">
+          <Lock className="mt-0.5 h-5 w-5 shrink-0" />
+          <div>
+            <AlertTitle>Immutable token</AlertTitle>
+            <AlertDescription>
+              Admin control has been permanently revoked. Supply and
+              permissions for this token can no longer change — a strong
+              trust signal for holders.
+            </AlertDescription>
+          </div>
+        </div>
+      </Alert>,
+    );
+  }
+
+  if (banners.length === 0) return null;
+
+  return <div className="mb-6 flex flex-col gap-3">{banners}</div>;
+}

--- a/frontend/lib/stellar.ts
+++ b/frontend/lib/stellar.ts
@@ -32,6 +32,14 @@ export interface TokenInfo {
   complianceNode?: string | null;
   authorizationRequired?: boolean;
   authorizationRevocable?: boolean;
+  isPaused?: boolean;
+  isLocked?: boolean;
+}
+
+/** Per-wallet authorization/freeze state for a token contract. */
+export interface WalletTokenState {
+  isAuthorized: boolean;
+  isFrozen: boolean;
 }
 
 export interface TokenHolder {
@@ -537,6 +545,22 @@ async function _fetchTokenInfo(
     // authorization checks not implemented or accessible; ignore.
   }
 
+  let isPaused = false;
+  try {
+    const pausedVal = await simulateCall(contractId, "is_paused", config);
+    isPaused = Boolean(pausedVal.b());
+  } catch {
+    // is_paused not implemented on this contract; assume not paused.
+  }
+
+  let isLocked = false;
+  try {
+    const lockedVal = await simulateCall(contractId, "is_locked", config);
+    isLocked = Boolean(lockedVal.b());
+  } catch {
+    // is_locked not implemented on this contract; assume not locked.
+  }
+
   return {
     name: decodeString(nameVal),
     symbol: decodeString(symbolVal),
@@ -556,7 +580,47 @@ async function _fetchTokenInfo(
     complianceNode,
     authorizationRequired,
     authorizationRevocable,
+    isPaused,
+    isLocked,
   };
+}
+
+/**
+ * Fetch a specific wallet's authorization/freeze state on a token contract.
+ * Guarded so contracts missing `is_authorized`/`is_frozen` degrade to the
+ * permissive defaults (authorized, not frozen).
+ */
+export async function fetchWalletTokenState(
+  contractId: string,
+  address: string,
+  config: NetworkConfig,
+): Promise<WalletTokenState> {
+  const addressScVal = new StellarSdk.Address(address).toScVal();
+
+  let isAuthorized = true;
+  try {
+    const authVal = await simulateCall(
+      contractId,
+      "is_authorized",
+      config,
+      [addressScVal],
+    );
+    isAuthorized = Boolean(authVal.b());
+  } catch {
+    // is_authorized not implemented; assume authorized.
+  }
+
+  let isFrozen = false;
+  try {
+    const frozenVal = await simulateCall(contractId, "is_frozen", config, [
+      addressScVal,
+    ]);
+    isFrozen = Boolean(frozenVal.b());
+  } catch {
+    // is_frozen not implemented; assume not frozen.
+  }
+
+  return { isAuthorized, isFrozen };
 }
 
 /**

--- a/frontend/lib/vesting.ts
+++ b/frontend/lib/vesting.ts
@@ -28,6 +28,7 @@ export interface VestingInfo {
   vestedAmount: bigint;
   releasableAmount: bigint;
   currentLedger: number;
+  isPaused: boolean;
 }
 
 /* ── XDR Decoders ──────────────────────────────────────────────────── */
@@ -213,11 +214,20 @@ export async function fetchVestingInfo(
   const releasableAmount = vestedAmount - schedule.released;
   const latestLedger = await server.getLatestLedger();
 
+  let isPaused = false;
+  try {
+    const pausedVal = await simulateCall(contractId, "is_paused", []);
+    isPaused = decodeBool(pausedVal);
+  } catch {
+    // is_paused not implemented on this vesting contract; assume not paused.
+  }
+
   return {
     schedule,
     vestedAmount,
     releasableAmount,
     currentLedger: latestLedger.sequence,
+    isPaused,
   };
 }
 


### PR DESCRIPTION
## Summary
- `TokenInfo` gained `isPaused`/`isLocked`, populated in `fetchTokenInfo` (guarded the same way as the existing `compliance_node` check, so contracts missing these methods just default to `false`).
- New `fetchWalletTokenState(contractId, address, config)` in `lib/stellar.ts` reads `is_authorized`/`is_frozen` for the connected wallet.
- New shared `TokenStatusBanner` component renders Paused, Immutable (framed as a trust signal), Authorization Required, and wallet-specific frozen/unauthorized banners. Wired into both `PublicTokenPage` and the dashboard header (`TokenDashboard`).
- `TransferPanel`'s submit button is disabled with inline helper text when the token is paused or the connected wallet is frozen/unauthorized.
- Vesting `release()` CTA in `ClaimVesting` is disabled with inline helper text when the vesting contract itself reports `is_paused`.

Closes #331

## Test plan
- [ ] Manually connect a wallet against a paused/locked/authorization-required testnet token and confirm banners + disabled CTAs render as expected on both the public token page and dashboard.