### PR TITLE
Add vesting solvency accounting

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Built for founders, DAOs, and developers who need a clean interface to launch to
 - Cliff + linear vesting schedules per wallet
 - Admin panel: mint, burn, transfer ownership
 - Real-time dashboard: supply metrics, holder table, vesting progress
+- Vesting solvency checks for funded grant visibility
 - Freighter wallet integration
 - Testnet & Mainnet support
 
@@ -44,7 +45,7 @@ soroban-token-launchpad/
 │   ├── hooks/              # Stellar/Soroban React hooks
 │   └── lib/                # Contract clients & utilities
 ├── scripts/                # Deploy & keygen scripts
-└── docs/                   # Architecture & event schema docs
+└── docs/                   # Architecture, event schema, and solvency docs
 ```
 
 ---

--- a/contracts/vesting/src/lib.rs
+++ b/contracts/vesting/src/lib.rs
@@ -38,6 +38,7 @@ pub enum DataKey {
     PendingAdmin,
     TokenContract,
     IsPaused,
+    TotalCommitted,
     Schedule(Address, u32),
     ScheduleCount(Address),
     RecipientCount,
@@ -62,6 +63,14 @@ pub struct ScheduleInput {
     pub total_amount: i128,
     pub cliff_ledger: u32,
     pub end_ledger: u32,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[contracttype]
+pub struct Solvency {
+    pub token_balance: i128,
+    pub total_committed: i128,
+    pub solvent: bool,
 }
 
 // ---------------------------------------------------------------------------
@@ -163,6 +172,8 @@ impl VestingContract {
         // Atomically transfer tokens from admin to this contract
         let token_client = soroban_sdk::token::Client::new(&env, &token_addr);
         token_client.transfer(&admin, &env.current_contract_address(), &total_amount);
+        Self::_increase_total_committed(&env, total_amount);
+        Self::_assert_solvent(&env, &token_addr);
 
         let schedule = VestingSchedule {
             recipient: recipient.clone(),
@@ -245,6 +256,8 @@ impl VestingContract {
         // Phase 2: Transfer total amount from admin to contract in one transaction
         let token_client = soroban_sdk::token::Client::new(&env, &token_addr);
         token_client.transfer(&admin, &env.current_contract_address(), &total_amount);
+        Self::_increase_total_committed(&env, total_amount);
+        Self::_assert_solvent(&env, &token_addr);
 
         // Phase 3: Create all schedules
         let mut created_count: u32 = 0;
@@ -304,6 +317,7 @@ impl VestingContract {
 
         schedule.released += releasable;
         env.storage().persistent().set(&key, &schedule);
+        Self::_decrease_total_committed(&env, releasable);
 
         // Extend TTL for the schedule to prevent archiving
         // saturating_sub prevents u32 underflow when the schedule has fully vested (current_ledger > end_ledger)
@@ -367,11 +381,13 @@ impl VestingContract {
         let vested = Self::_vested_amount(&env, &schedule);
         let releasable = vested - schedule.released;
         let unvested = schedule.total_amount - vested;
+        let committed = schedule.total_amount - schedule.released;
 
         // Update schedule state
         schedule.revoked = true;
         schedule.released = vested; // All vested tokens are now accounted for as released (or being released)
         env.storage().persistent().set(&key, &schedule);
+        Self::_decrease_total_committed(&env, committed);
 
         let token_addr: Address = env
             .storage()
@@ -452,6 +468,28 @@ impl VestingContract {
     pub fn released_amount(env: Env, recipient: Address, index: Option<u32>) -> i128 {
         let (_, schedule) = Self::_load_schedule(&env, &recipient, index);
         schedule.released
+    }
+
+    /// Total tokens still committed to active vesting schedules.
+    pub fn total_committed(env: Env) -> i128 {
+        Self::_total_committed(&env)
+    }
+
+    /// Compare the vesting contract's live token balance to outstanding grants.
+    pub fn solvency(env: Env) -> Solvency {
+        let token_addr: Address = env
+            .storage()
+            .instance()
+            .get(&DataKey::TokenContract)
+            .expect("not initialized");
+        let total_committed = Self::_total_committed(&env);
+        let token_balance = Self::_token_balance(&env, &token_addr);
+
+        Solvency {
+            token_balance,
+            total_committed,
+            solvent: token_balance >= total_committed,
+        }
     }
 
     /// Returns `true` if the contract is currently paused.
@@ -600,6 +638,42 @@ impl VestingContract {
         let key = DataKey::ScheduleCount(recipient.clone());
         env.storage().persistent().set(&key, &count);
         Self::_extend_persistent_ttl(env, &key, ttl_ledgers);
+    }
+
+    fn _total_committed(env: &Env) -> i128 {
+        env.storage()
+            .instance()
+            .get(&DataKey::TotalCommitted)
+            .unwrap_or(0)
+    }
+
+    fn _set_total_committed(env: &Env, amount: i128) {
+        env.storage()
+            .instance()
+            .set(&DataKey::TotalCommitted, &amount);
+    }
+
+    fn _increase_total_committed(env: &Env, amount: i128) {
+        let total = Self::_total_committed(env)
+            .checked_add(amount)
+            .expect("total committed overflow");
+        Self::_set_total_committed(env, total);
+    }
+
+    fn _decrease_total_committed(env: &Env, amount: i128) {
+        Self::_set_total_committed(env, Self::_total_committed(env).saturating_sub(amount));
+    }
+
+    fn _token_balance(env: &Env, token_addr: &Address) -> i128 {
+        let token_client = soroban_sdk::token::Client::new(env, token_addr);
+        token_client.balance(&env.current_contract_address())
+    }
+
+    fn _assert_solvent(env: &Env, token_addr: &Address) {
+        assert!(
+            Self::_token_balance(env, token_addr) >= Self::_total_committed(env),
+            "vesting contract underfunded"
+        );
     }
 
     fn _resolve_schedule_index(env: &Env, recipient: &Address, index: Option<u32>) -> u32 {
@@ -911,6 +985,108 @@ mod test {
         assert_eq!(schedule.end_ledger, 200);
         assert_eq!(schedule.released, 0);
         assert!(!schedule.revoked);
+    }
+
+    #[test]
+    fn test_total_committed_tracks_schedule_lifecycle() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let contract_id = env.register_contract(None, VestingContract);
+        let client = VestingContractClient::new(&env, &contract_id);
+
+        let admin = Address::generate(&env);
+        let recipient = Address::generate(&env);
+        let other = Address::generate(&env);
+        let token_addr = env.register_stellar_asset_contract(admin.clone());
+        let token_client = soroban_sdk::token::Client::new(&env, &token_addr);
+        let asset_client = soroban_sdk::token::StellarAssetClient::new(&env, &token_addr);
+
+        client.initialize(&admin, &token_addr);
+        asset_client.mint(&admin, &5_000);
+
+        assert_eq!(client.total_committed(), 0);
+
+        client.create_schedule(&recipient, &1_000, &100, &200);
+        assert_eq!(client.total_committed(), 1_000);
+        assert_eq!(token_client.balance(&contract_id), 1_000);
+        assert_eq!(
+            client.solvency(),
+            Solvency {
+                token_balance: 1_000,
+                total_committed: 1_000,
+                solvent: true,
+            }
+        );
+
+        env.ledger().set_sequence_number(150);
+        release_latest(&client, &recipient);
+        assert_eq!(client.total_committed(), 500);
+        assert_eq!(token_client.balance(&contract_id), 500);
+
+        client.create_schedule(&other, &300, &200, &300);
+        assert_eq!(client.total_committed(), 800);
+        assert_eq!(token_client.balance(&contract_id), 800);
+
+        revoke_latest(&client, &recipient);
+        assert_eq!(client.total_committed(), 300);
+        assert_eq!(token_client.balance(&contract_id), 300);
+    }
+
+    #[test]
+    fn test_solvency_reports_external_token_drain() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let contract_id = env.register_contract(None, VestingContract);
+        let client = VestingContractClient::new(&env, &contract_id);
+
+        let admin = Address::generate(&env);
+        let recipient = Address::generate(&env);
+        let token_addr = env.register_stellar_asset_contract(admin.clone());
+        let token_client = soroban_sdk::token::Client::new(&env, &token_addr);
+        let asset_client = soroban_sdk::token::StellarAssetClient::new(&env, &token_addr);
+
+        client.initialize(&admin, &token_addr);
+        asset_client.mint(&admin, &1_000);
+        client.create_schedule(&recipient, &1_000, &100, &200);
+
+        // Models any token-side admin action that drains already committed funds
+        // from the vesting contract, such as clawback on a clawbackable token.
+        token_client.transfer(&contract_id, &admin, &400);
+
+        assert_eq!(
+            client.solvency(),
+            Solvency {
+                token_balance: 600,
+                total_committed: 1_000,
+                solvent: false,
+            }
+        );
+    }
+
+    #[test]
+    #[should_panic(expected = "vesting contract underfunded")]
+    fn test_create_schedule_rejects_when_existing_commitments_are_underfunded() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let contract_id = env.register_contract(None, VestingContract);
+        let client = VestingContractClient::new(&env, &contract_id);
+
+        let admin = Address::generate(&env);
+        let recipient = Address::generate(&env);
+        let other = Address::generate(&env);
+        let token_addr = env.register_stellar_asset_contract(admin.clone());
+        let token_client = soroban_sdk::token::Client::new(&env, &token_addr);
+        let asset_client = soroban_sdk::token::StellarAssetClient::new(&env, &token_addr);
+
+        client.initialize(&admin, &token_addr);
+        asset_client.mint(&admin, &2_000);
+        client.create_schedule(&recipient, &1_000, &100, &200);
+        token_client.transfer(&contract_id, &admin, &400);
+
+        client.create_schedule(&other, &100, &100, &200);
     }
 
     #[test]

--- a/docs/vesting-solvency.md
+++ b/docs/vesting-solvency.md
@@ -1,0 +1,29 @@
+# Vesting Solvency
+
+The vesting contract keeps a live `total_committed` counter for tokens still
+owed to active schedules. The counter increases when schedules are created and
+decreases when tokens are released or a schedule is revoked.
+
+Recipients and auditors can call `solvency()` to compare that commitment total
+with the vesting contract's current token balance:
+
+- `token_balance`: live balance held by the vesting contract.
+- `total_committed`: amount still owed to active schedules.
+- `solvent`: `true` when `token_balance >= total_committed`.
+
+The token admin can still undermine a vesting contract if they retain token
+admin powers. For example, a token with clawback enabled can claw tokens back
+from the vesting contract address after schedules are funded. A paused or
+frozen token can also prevent otherwise valid releases from completing.
+
+For grants that need strong credibility, use one of these patterns:
+
+- Call `revoke_admin` on the token contract after funding grants, if the token
+  no longer needs admin-managed minting, clawback, pause, or freeze powers.
+- Use a separate token admin that is independent from the vesting admin.
+- Prefer multisig or governed admin accounts for high-value grant programs.
+
+The solvency badge in the frontend is a trust signal, not an enforcement layer.
+It shows whether the vesting contract is currently funded enough to cover its
+recorded commitments, so recipients can spot underfunding before attempting a
+claim.

--- a/frontend/app/claim/ClaimVesting.tsx
+++ b/frontend/app/claim/ClaimVesting.tsx
@@ -2,16 +2,19 @@
 
 import { useCallback, useState } from "react";
 import { Button } from "@/components/ui/Button";
+import { VestingSolvencyBadge } from "@/components/VestingSolvencyBadge";
 import { useToast } from "@/app/providers/ToastProvider";
 import { useWallet } from "@/app/hooks/useWallet";
 import {
   fetchScheduleCount,
   fetchVestingInfo,
+  fetchVestingSolvency,
   buildReleaseTx,
   submitTx,
   formatTokenAmount,
   truncateAddress,
   type VestingInfo,
+  type VestingSolvency,
 } from "@/lib/vesting";
 
 /* ── Soroban contract-ID regex (56 chars starting with C) ──────────── */
@@ -24,6 +27,9 @@ export function ClaimVesting() {
   const [contractId, setContractId] = useState("");
   // One VestingInfo entry per schedule index
   const [schedules, setSchedules] = useState<VestingInfo[]>([]);
+  const [solvency, setSolvency] = useState<
+    VestingSolvency | null | undefined
+  >();
   const [loading, setLoading] = useState(false);
   // Track which schedule index is currently releasing
   const [releasingIndex, setReleasingIndex] = useState<number | null>(null);
@@ -48,10 +54,15 @@ export function ClaimVesting() {
 
     setError(null);
     setSchedules([]);
+    setSolvency(undefined);
     setLoading(true);
 
     try {
-      const count = await fetchScheduleCount(trimmed, publicKey);
+      const [count, solvencyState] = await Promise.all([
+        fetchScheduleCount(trimmed, publicKey),
+        fetchVestingSolvency(trimmed),
+      ]);
+      setSolvency(solvencyState);
 
       if (count === 0) {
         setError("No vesting schedule found for your wallet on this contract.");
@@ -111,11 +122,11 @@ export function ClaimVesting() {
         });
 
         // Refresh this schedule
-        const updated = await fetchVestingInfo(
-          contractId.trim(),
-          publicKey,
-          scheduleIndex,
-        );
+        const [updated, solvencyState] = await Promise.all([
+          fetchVestingInfo(contractId.trim(), publicKey, scheduleIndex),
+          fetchVestingSolvency(contractId.trim()),
+        ]);
+        setSolvency(solvencyState);
         setSchedules((prev) => {
           const next = [...prev];
           next[scheduleIndex] = updated;
@@ -191,6 +202,10 @@ export function ClaimVesting() {
               </p>
             )}
           </div>
+
+          {solvency !== undefined && (
+            <VestingSolvencyBadge solvency={solvency} />
+          )}
 
           {/* ── One card per schedule ─────────────────────────────────── */}
           {schedules.map((info, idx) => (

--- a/frontend/app/dashboard/[contractId]/VestingProgress.tsx
+++ b/frontend/app/dashboard/[contractId]/VestingProgress.tsx
@@ -17,6 +17,11 @@ import {
   submitTransaction,
   type VestingScheduleInfo,
 } from "@/lib/stellar";
+import { VestingSolvencyBadge } from "@/components/VestingSolvencyBadge";
+import {
+  fetchVestingSolvency,
+  type VestingSolvency,
+} from "@/lib/vesting";
 import { useNetwork } from "@/app/providers/NetworkProvider";
 // import { CopyButton } from "@/components/ui/CopyButton";
 import { useSoroban } from "@/hooks/useSoroban";
@@ -426,6 +431,9 @@ export default function VestingProgress({ decimals }: { decimals: number }) {
   const [vestingContract, setVestingContract] = useState("");
   const [recipient, setRecipient] = useState("");
   const [schedule, setSchedule] = useState<VestingScheduleInfo | null>(null);
+  const [solvency, setSolvency] = useState<
+    VestingSolvency | null | undefined
+  >();
   const [currentLedger, setCurrentLedger] = useState(0);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -436,14 +444,17 @@ export default function VestingProgress({ decimals }: { decimals: number }) {
     setLoading(true);
     setError(null);
     setSchedule(null);
+    setSolvency(undefined);
 
     try {
-      const [sched, ledger] = await Promise.all([
+      const [sched, ledger, solvencyState] = await Promise.all([
         fetchVestingSchedule(vestingContract.trim(), recipient.trim()),
         fetchCurrentLedger(),
+        fetchVestingSolvency(vestingContract.trim()),
       ]);
       setSchedule(sched);
       setCurrentLedger(ledger);
+      setSolvency(solvencyState);
     } catch (err) {
       setError(
         err instanceof Error
@@ -504,6 +515,10 @@ export default function VestingProgress({ decimals }: { decimals: number }) {
           <AlertCircle className="mt-0.5 h-4 w-4 shrink-0" />
           <p>{error}</p>
         </div>
+      )}
+
+      {solvency !== undefined && (
+        <VestingSolvencyBadge solvency={solvency} decimals={decimals} />
       )}
 
       {/* Result */}

--- a/frontend/components/VestingSolvencyBadge.tsx
+++ b/frontend/components/VestingSolvencyBadge.tsx
@@ -1,0 +1,67 @@
+"use client";
+
+import { AlertTriangle, ShieldCheck } from "lucide-react";
+import {
+  formatTokenAmount,
+  type VestingSolvency,
+} from "@/lib/vesting";
+
+export function VestingSolvencyBadge({
+  solvency,
+  decimals = 7,
+}: {
+  solvency: VestingSolvency | null;
+  decimals?: number;
+}) {
+  if (!solvency) {
+    return (
+      <div className="rounded-lg border border-white/10 bg-white/5 p-4">
+        <p className="text-sm font-semibold text-gray-200">
+          Solvency unavailable
+        </p>
+        <p className="mt-1 text-xs leading-relaxed text-gray-400">
+          This vesting contract does not expose live commitment accounting.
+        </p>
+      </div>
+    );
+  }
+
+  const Icon = solvency.solvent ? ShieldCheck : AlertTriangle;
+  const tone = solvency.solvent
+    ? "border-green-500/30 bg-green-500/10 text-green-200"
+    : "border-red-500/35 bg-red-500/10 text-red-200";
+  const iconTone = solvency.solvent ? "text-green-300" : "text-red-300";
+  const label = solvency.solvent ? "Solvent" : "Underfunded";
+
+  return (
+    <div className={`rounded-lg border p-4 ${tone}`}>
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <div className="flex items-start gap-3">
+          <Icon className={`mt-0.5 h-5 w-5 shrink-0 ${iconTone}`} />
+          <div>
+            <p className="text-sm font-semibold">{label}</p>
+            <p className="mt-1 text-xs leading-relaxed opacity-85">
+              {solvency.solvent
+                ? "Live token balance covers all active vesting commitments."
+                : "Live token balance is below active vesting commitments."}
+            </p>
+          </div>
+        </div>
+        <div className="grid grid-cols-2 gap-2 text-xs sm:min-w-64">
+          <div>
+            <p className="opacity-70">Balance</p>
+            <p className="font-mono font-semibold">
+              {formatTokenAmount(solvency.tokenBalance, decimals)}
+            </p>
+          </div>
+          <div>
+            <p className="opacity-70">Committed</p>
+            <p className="font-mono font-semibold">
+              {formatTokenAmount(solvency.totalCommitted, decimals)}
+            </p>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/lib/vesting.ts
+++ b/frontend/lib/vesting.ts
@@ -31,6 +31,12 @@ export interface VestingInfo {
   isPaused: boolean;
 }
 
+export interface VestingSolvency {
+  tokenBalance: bigint;
+  totalCommitted: bigint;
+  solvent: boolean;
+}
+
 /* ── XDR Decoders ──────────────────────────────────────────────────── */
 
 function decodeI128(val: StellarSdk.xdr.ScVal): bigint {
@@ -50,6 +56,22 @@ function decodeAddress(val: StellarSdk.xdr.ScVal): string {
 
 function decodeBool(val: StellarSdk.xdr.ScVal): boolean {
   return val.b();
+}
+
+function decodeSolvency(val: StellarSdk.xdr.ScVal): VestingSolvency {
+  const fields = val.map();
+  if (!fields) throw new Error("Unexpected result type from solvency");
+
+  const fieldMap = new Map<string, StellarSdk.xdr.ScVal>();
+  for (const entry of fields) {
+    fieldMap.set(entry.key().sym().toString(), entry.val());
+  }
+
+  return {
+    tokenBalance: decodeI128(fieldMap.get("token_balance")!),
+    totalCommitted: decodeI128(fieldMap.get("total_committed")!),
+    solvent: decodeBool(fieldMap.get("solvent")!),
+  };
 }
 
 /* ── Simulate a read-only contract call ────────────────────────────── */
@@ -229,6 +251,17 @@ export async function fetchVestingInfo(
     currentLedger: latestLedger.sequence,
     isPaused,
   };
+}
+
+/** Fetch live vesting solvency when supported by the deployed contract. */
+export async function fetchVestingSolvency(
+  contractId: string,
+): Promise<VestingSolvency | null> {
+  try {
+    return decodeSolvency(await simulateCall(contractId, "solvency"));
+  } catch {
+    return null;
+  }
 }
 
 /**


### PR DESCRIPTION
Closes #361
Adds vesting solvency accounting so committed schedules are tracked against the contract’s live token balance.
Changes:
Adds TotalCommitted storage and total_committed() getter.
Adds solvency() helper returning token balance, committed amount, and solvent status.
Increments commitments on schedule creation and decrements on release/revoke.
Rejects new schedules when existing commitments are already underfunded.
Adds a frontend solvency badge for vesting recipient/admin views.
Documents token admin clawback risk and recommends credible admin setups.
Verification:
cargo fmt -p soroban-vesting
cargo test -p soroban-vesting passed: 38 tests
git diff --check passed
npm run type-check could not run because local tsc/node_modules is missing.