### PR TITLE
Avoid hard admin unwrap in mint event topic

### DIFF
--- a/contracts/token/src/lib.rs
+++ b/contracts/token/src/lib.rs
@@ -1024,7 +1024,7 @@ impl TokenContract {
             .storage()
             .instance()
             .get(&DataKey::Admin)
-            .expect("admin revoked");
+            .unwrap_or_else(|| env.current_contract_address());
         env.events()
             .publish((symbol_short!("mint"), admin, to.clone()), amount);
     }


### PR DESCRIPTION
Closes #407
## Summary
- Replace `_mint`'s hard `DataKey::Admin` unwrap with an optional read.
- Fall back to `env.current_contract_address()` for the SEP-41 mint event topic when admin has been revoked.
- Removes the implicit admin-present invariant from the mint hot path.

Fixes #407.

## Testing
- `cargo test -p soroban-token` could not complete locally because the Windows environment is missing MSVC `link.exe`.