### PR TITLE
Title: Fix hardcoded expirationLedger: 1000 in allowance revocation (#410)

### DIFF
--- a/contracts/token/src/lib.rs
+++ b/contracts/token/src/lib.rs
@@ -540,6 +540,10 @@ impl TokenContract {
 
         let key = DataKey::Allowance(from.clone(), spender.clone());
 
+        // NOTE: frontend clients (buildRevokeAllowanceArgs) pass expiration_ledger = 0
+        // when revoking an allowance.  The 0 is safe because the branch below ignores
+        // expiration_ledger when amount == 0.  Do NOT add an assertion on
+        // expiration_ledger here without also updating the frontend.
         if amount == 0 {
             env.storage().temporary().remove(&key);
         } else {

--- a/frontend/__tests__/transactionSimulator.test.tsx
+++ b/frontend/__tests__/transactionSimulator.test.tsx
@@ -6,6 +6,7 @@
 
 import "@testing-library/jest-dom";
 import {
+  buildRevokeAllowanceArgs,
   parseSorobanError,
   // simulateTransaction,
 } from "@/lib/transactionSimulator";
@@ -314,6 +315,39 @@ describe("Simulation with Mock RPC", () => {
   it("returns warnings for high fees", async () => {
     // Mock RPC returning high cost
     // expect(result.warnings).toContain("High");
+  });
+});
+
+// ───────────────────────────────────────────────────────────────────────────
+// buildRevokeAllowanceArgs Tests
+// ───────────────────────────────────────────────────────────────────────────
+
+describe("buildRevokeAllowanceArgs", () => {
+  it("returns four ScVal arguments", () => {
+    const owner = "GBPLA3EQJGNQFHZNQWUZ3Z7YZY7QZ5RZQ5JQ5JQ5JQ5JQ5JQ5JQ5JQ5";
+    const spender = "GCTV2QEQJGNQFHZNQWUZ3Z7YZY7QZ5RZQ5JQ5JQ5JQ5JQ5JQ5JQ5JQ5";
+    const args = buildRevokeAllowanceArgs(owner, spender);
+
+    expect(args).toHaveLength(4);
+  });
+
+  it("passes 0 for amount and expiration_ledger", () => {
+    const owner = "GBPLA3EQJGNQFHZNQWUZ3Z7YZY7QZ5RZQ5JQ5JQ5JQ5JQ5JQ5JQ5JQ5";
+    const spender = "GCTV2QEQJGNQFHZNQWUZ3Z7YZY7QZ5RZQ5JQ5JQ5JQ5JQ5JQ5JQ5JQ5";
+    const args = buildRevokeAllowanceArgs(owner, spender);
+
+    // owner and spender are Address ScVals — just verify they're present
+    expect(args[0]).toBeDefined();
+    expect(args[1]).toBeDefined();
+
+    // amount (i128) must be 0
+    const amountVal = args[2].value() as { hi: number; lo: number };
+    expect(amountVal.hi).toBe(0);
+    expect(amountVal.lo).toBe(0);
+
+    // expiration_ledger (u32) must be 0
+    const expVal = args[3].value() as number;
+    expect(expVal).toBe(0);
   });
 });
 

--- a/frontend/app/dashboard/allowances/AllowancesPage.tsx
+++ b/frontend/app/dashboard/allowances/AllowancesPage.tsx
@@ -9,7 +9,7 @@ import { Input } from "@/components/ui/Input";
 import { AlertCircle, Wallet, RefreshCw } from "lucide-react";
 import type { AllowanceInfo } from "@/components/ui/AllowanceCard";
 import {
-  buildApproveTransaction,
+  buildRevokeAllowanceTransaction,
   fetchApprovedSpendersFromEvents,
   fetchCurrentLedger,
   fetchTokenDecimals,
@@ -102,12 +102,10 @@ export function AllowancesPage({
       return;
     }
 
-    const xdr = await buildApproveTransaction({
+    const xdr = await buildRevokeAllowanceTransaction({
       tokenContractId: contractId,
       ownerAddress: publicKey,
       spenderAddress,
-      amount: BigInt(0),
-      expirationLedger: 1000,
       config: networkConfig,
     });
 

--- a/frontend/components/AllowanceManager.tsx
+++ b/frontend/components/AllowanceManager.tsx
@@ -11,6 +11,7 @@ import { useWallet } from "@/app/hooks/useWallet";
 import { useNetwork } from "@/app/providers/NetworkProvider";
 import {
   buildApproveTransaction,
+  buildRevokeAllowanceTransaction,
   fetchApprovedSpendersFromEvents,
   fetchCurrentLedger,
   fetchTokenDecimals,
@@ -115,12 +116,10 @@ export function AllowanceManager({ contractId: initialContractId }: AllowanceMan
 
     setRevokingSpender(spenderAddress);
     try {
-      const xdr = await buildApproveTransaction({
+      const xdr = await buildRevokeAllowanceTransaction({
         tokenContractId: contractId,
         ownerAddress: publicKey,
         spenderAddress,
-        amount: BigInt(0),
-        expirationLedger: 1000,
         config: networkConfig,
       });
 

--- a/frontend/components/forms/RevokeAllowanceForm.tsx
+++ b/frontend/components/forms/RevokeAllowanceForm.tsx
@@ -9,7 +9,10 @@ import { Input } from "@/components/ui/Input";
 import { PreflightCheckDisplay } from "@/components/ui/PreflightCheck";
 import { useTransactionSimulator } from "@/hooks/useTransactionSimulator";
 import { useWallet } from "@/app/hooks/useWallet";
-import { buildApproveTransaction, submitTransaction } from "@/lib/stellar";
+import {
+  buildRevokeAllowanceTransaction,
+  submitTransaction,
+} from "@/lib/stellar";
 import { useNetwork } from "@/app/providers/NetworkProvider";
 import { AlertCircle, CheckCircle, Trash2, Loader2 } from "lucide-react";
 
@@ -100,12 +103,10 @@ export function RevokeAllowanceForm({ onSuccess, onError }: RevokeAllowanceFormP
 
     setIsSubmitting(true);
     try {
-      const xdr = await buildApproveTransaction({
+      const xdr = await buildRevokeAllowanceTransaction({
         tokenContractId: formData.tokenContractId,
         ownerAddress: publicKey,
         spenderAddress: formData.spenderAddress,
-        amount: BigInt(0),
-        expirationLedger: 1000,
         config: networkConfig,
       });
 

--- a/frontend/lib/stellar.ts
+++ b/frontend/lib/stellar.ts
@@ -2,6 +2,7 @@ import * as StellarSdk from "@stellar/stellar-sdk";
 import { type NetworkConfig } from "../types/network";
 import { fetchIndexedEvents } from "./indexer";
 import { wrapRpcCall } from "./soroban";
+import { buildRevokeAllowanceArgs } from "./transactionSimulator";
 
 // ---------------------------------------------------------------------------
 // Config — defaults to Stellar Testnet, overridable via localStorage
@@ -1579,6 +1580,39 @@ export async function buildApproveTransaction(params: {
         expirationScVal,
       ),
     )
+    .setTimeout(30)
+    .build();
+
+  const assembled = await simulateAndAssembleTransaction(tx, config);
+  return assembled.build().toXDR();
+}
+
+/**
+ * Build a transaction XDR that revokes an allowance on a SEP-41 token.
+ *
+ * Delegates argument construction to `buildRevokeAllowanceArgs` so the
+ * preflight simulation and the real submission use identical arguments.
+ * See that function and `contracts/token/src/lib.rs` for the rationale.
+ */
+export async function buildRevokeAllowanceTransaction(params: {
+  tokenContractId: string;
+  ownerAddress: string;
+  spenderAddress: string;
+  config: NetworkConfig;
+}): Promise<string> {
+  const { tokenContractId, ownerAddress, spenderAddress, config } = params;
+
+  const contract = new StellarSdk.Contract(tokenContractId);
+  const args = buildRevokeAllowanceArgs(ownerAddress, spenderAddress);
+
+  const horizon = new StellarSdk.Horizon.Server(config.horizonUrl);
+  const sourceAccount = await horizon.loadAccount(ownerAddress);
+
+  const tx = new StellarSdk.TransactionBuilder(sourceAccount, {
+    fee: StellarSdk.BASE_FEE,
+    networkPassphrase: config.passphrase,
+  })
+    .addOperation(contract.call("approve", ...args))
     .setTimeout(30)
     .build();
 

--- a/frontend/lib/transactionSimulator.ts
+++ b/frontend/lib/transactionSimulator.ts
@@ -503,8 +503,32 @@ export async function simulateApprove(
 }
 
 /**
+ * Build the ScVal arguments for revoking an allowance on a SEP-41 token.
+ *
+ * Revoke is implemented as `approve` with amount = 0. The contract's
+ * `if amount == 0` branch ignores `expiration_ledger`, so we pass 0
+ * for both parameters. Any caller that builds an `approve` transaction
+ * or simulation to revoke an allowance MUST use this helper so that
+ * the preflight and the real submission stay in sync.
+ *
+ * See `contracts/token/src/lib.rs` — the `if amount == 0` branch.
+ */
+export function buildRevokeAllowanceArgs(
+  ownerAddress: string,
+  spenderAddress: string,
+): StellarSdk.xdr.ScVal[] {
+  return [
+    new StellarSdk.Address(ownerAddress).toScVal(),
+    new StellarSdk.Address(spenderAddress).toScVal(),
+    StellarSdk.nativeToScVal(BigInt(0), { type: "i128" }),
+    StellarSdk.nativeToScVal(BigInt(0), { type: "u32" }),
+  ];
+}
+
+/**
  * Simulate a token revoke allowance pre-flight check.
- * Revoke is implemented as approve with 0 amount.
+ * Revoke is implemented as approve with 0 amount — see
+ * `buildRevokeAllowanceArgs` for details.
  */
 export async function simulateRevokeAllowance(
   contractId: string,
@@ -520,12 +544,7 @@ export async function simulateRevokeAllowance(
     };
   }
 
-  const args = [
-    new StellarSdk.Address(ownerAddress).toScVal(),
-    new StellarSdk.Address(spenderAddress).toScVal(),
-    StellarSdk.nativeToScVal(BigInt(0), { type: "i128" }),
-    StellarSdk.nativeToScVal(BigInt(1000), { type: "u32" }),
-  ];
+  const args = buildRevokeAllowanceArgs(ownerAddress, spenderAddress);
 
   return simulateTransaction(contractId, "approve", args, config, ownerAddress);
 }


### PR DESCRIPTION
Closes #410.

Revoking an allowance passed a fixed, long-past expiration_ledger (1000) in two places — AllowanceManager.tsx:123 and transactionSimulator.ts:507,526-527. This only worked because #344 made approve skip the expiry assertion when amount == 0, taking the remove branch instead and ignoring the argument entirely. Before #344 this would have reverted, and it will revert again if a bound on expiration_ledger is ever reinstated for the zero-amount case.

Changes:

Added a shared buildRevokeAllowanceArgs helper that passes 0 for both amount and expiration_ledger, replacing the two independent hardcoded literals in AllowanceManager.tsx and transactionSimulator.ts
Updated both call sites to use the shared helper instead of duplicating the values by hand

Added a comment at the contract's if amount == 0 branch noting that clients rely on expiration_ledger being ignored there, so it can't be tightened without a corresponding client change
Added test coverage for the revoke path in transactionSimulator.test.tsx

Why: The two literals had to stay in sync manually, and since the simulator gates the real submission, a divergence between the two would produce the same failure shape as #83 — preflight and transaction disagreeing. Centralizing the revoke args removes that risk and makes the dependency on the contract's zero-amount branch explicit instead of implicit.